### PR TITLE
feat(lib): New lib: Mp4uploadExtractor

### DIFF
--- a/lib/mp4upload-extractor/build.gradle.kts
+++ b/lib/mp4upload-extractor/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+    id("com.android.library")
+    kotlin("android")
+}
+
+android {
+    compileSdk = AndroidConfig.compileSdk
+    namespace = "eu.kanade.tachiyomi.lib.mp4uploadextractor"
+
+    defaultConfig {
+        minSdk = AndroidConfig.minSdk
+    }
+}
+
+dependencies {
+    implementation("dev.datlag.jsunpacker:jsunpacker:1.0.1") {
+        exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk8")
+    }
+    compileOnly(libs.bundles.common)
+}

--- a/lib/mp4upload-extractor/src/main/java/eu/kanade/tachiyomi/lib/mp4uploadextractor/Mp4uploadExtractor.kt
+++ b/lib/mp4upload-extractor/src/main/java/eu/kanade/tachiyomi/lib/mp4uploadextractor/Mp4uploadExtractor.kt
@@ -1,0 +1,36 @@
+package eu.kanade.tachiyomi.lib.mp4uploadextractor
+
+import eu.kanade.tachiyomi.animesource.model.Video
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.util.asJsoup
+import okhttp3.Headers
+import okhttp3.OkHttpClient
+import dev.datlag.jsunpacker.JsUnpacker
+
+class Mp4uploadExtractor(private val client: OkHttpClient) {
+    fun videosFromUrl(url: String, headers: Headers, prefix: String = "", suffix: String = ""): List<Video> {
+        val newHeaders = headers.newBuilder()
+            .add("referer", REFERER)
+            .build()
+
+        val doc = client.newCall(GET(url, newHeaders)).execute().use { it.asJsoup() }
+
+        val script = doc.selectFirst("script:containsData(eval):containsData(p,a,c,k,e,d)")?.data()
+            ?.let(JsUnpacker::unpackAndCombine)
+            ?: doc.selectFirst("script:containsData(player.src)")?.data()
+            ?: return emptyList()
+
+        val videoUrl = script.substringAfter(".src(").substringBefore(")")
+            .substringAfter("src:").substringAfter('"').substringBefore('"')
+
+        val resolution = QUALITY_REGEX.find(script)?.groupValues?.let { "${it[1]}p" } ?: "Unknown resolution"
+        val quality = "${prefix}Mp4Upload - $resolution$suffix"
+
+        return listOf(Video(videoUrl, quality, videoUrl, newHeaders))
+    }
+
+    companion object {
+        private val QUALITY_REGEX by lazy { """\WHEIGHT=(\d+)""".toRegex() }
+        private const val REFERER = "https://mp4upload.com/"
+    }
+}


### PR DESCRIPTION
Looks like mp4upload isn't using jspacker anymore, so the jsunpacker part may be useless, but to prevent future headache it will not be removed (yet).