### PR TITLE
fix(all/googledriveindex): fix file sizes & use parseAs function

### DIFF
--- a/src/all/googledriveindex/build.gradle
+++ b/src/all/googledriveindex/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'GoogleDriveIndex'
     pkgNameSuffix = 'all.googledriveindex'
     extClass = '.GoogleDriveIndex'
-    extVersionCode = 6
+    extVersionCode = 7
     libVersion = '13'
 }
 

--- a/src/all/googledriveindex/src/eu/kanade/tachiyomi/animeextension/all/googledriveindex/GoogleDriveIndex.kt
+++ b/src/all/googledriveindex/src/eu/kanade/tachiyomi/animeextension/all/googledriveindex/GoogleDriveIndex.kt
@@ -535,9 +535,9 @@ class GoogleDriveIndex : ConfigurableAnimeSource, AnimeHttpSource() {
 
     private fun formatFileSize(bytes: Long): String {
         return when {
-            bytes >= 1000000000 -> "%.2f GB".format(bytes / 1000000000.0)
-            bytes >= 100000 -> "%.2f MB".format(bytes / 1000000.0)
-            bytes >= 1000 -> "%.2f KB".format(bytes / 1000.0)
+            bytes >= 1_000_000_000 -> "%.2f GB".format(bytes / 1_000_000_000.0)
+            bytes >= 1_000_000 -> "%.2f MB".format(bytes / 1_000_000.0)
+            bytes >= 1_000 -> "%.2f KB".format(bytes / 1_000.0)
             bytes > 1 -> "$bytes bytes"
             bytes == 1L -> "$bytes byte"
             else -> ""


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
