### PR TITLE
feat(en/aniwatch): Update domains

### DIFF
--- a/src/en/aniwatch/build.gradle
+++ b/src/en/aniwatch/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'AniWatch.to'
     pkgNameSuffix = 'en.zoro'
     extClass = '.AniWatch'
-    extVersionCode = 31
+    extVersionCode = 32
     libVersion = '13'
 }
 


### PR DESCRIPTION
Added the option to switch to `kaido.to`, since it doesn't run into cloudflare issues.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
