### PR TITLE
fix(en/rule34video): Fix search and add URL activity

### DIFF
--- a/src/en/rule34video/AndroidManifest.xml
+++ b/src/en/rule34video/AndroidManifest.xml
@@ -1,2 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <activity
+            android:name=".en.rule34video.Rule34VideoUrlActivity"
+            android:excludeFromRecents="true"
+            android:exported="true"
+            android:theme="@android:style/Theme.NoDisplay">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="rule34video.com"
+                    android:pathPattern="/..*"
+                    android:scheme="https" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/src/en/rule34video/build.gradle
+++ b/src/en/rule34video/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Rule34Video'
     pkgNameSuffix = 'en.rule34video'
     extClass = '.Rule34Video'
-    extVersionCode = 5
+    extVersionCode = 6
     libVersion = '13'
     containsNsfw = true
 }

--- a/src/en/rule34video/src/eu/kanade/tachiyomi/animeextension/en/rule34video/Rule34Video.kt
+++ b/src/en/rule34video/src/eu/kanade/tachiyomi/animeextension/en/rule34video/Rule34Video.kt
@@ -144,7 +144,12 @@ class Rule34Video : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
         }
 
         return if (query.isNotEmpty()) {
-            GET("$baseUrl/search/$query/?flag1=${categoryFilter.toUriPart()}&sort_by=$sortType&from_videos=$page&tag_ids=all%2C${tagSearch.toUriPart()}")
+            if (query.startsWith("slug:")) {
+                var newQuery = query.split(':')[1].dropLastWhile { it.isDigit() }
+                GET("$baseUrl/search/$newQuery")
+            } else {
+                GET("$baseUrl/search/${query.replace(Regex("\\s"), "-")}/?flag1=${categoryFilter.toUriPart()}&sort_by=$sortType&from_videos=$page&tag_ids=all%2C${tagSearch.toUriPart()}")
+            }
         } else {
             GET("$baseUrl/search/?flag1=${categoryFilter.toUriPart()}&sort_by=$sortType&from_videos=$page&tag_ids=all%2C${tagSearch.toUriPart()}")
         }
@@ -245,5 +250,9 @@ class Rule34Video : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
     private open class UriPartFilter(displayName: String, val vals: Array<Pair<String, String>>) :
         AnimeFilter.Select<String>(displayName, vals.map { it.first }.toTypedArray()) {
         fun toUriPart() = vals[state].second
+    }
+
+    companion object {
+        const val PREFIX_SEARCH = "slug:"
     }
 }

--- a/src/en/rule34video/src/eu/kanade/tachiyomi/animeextension/en/rule34video/Rule34VideoUrlActivity.kt
+++ b/src/en/rule34video/src/eu/kanade/tachiyomi/animeextension/en/rule34video/Rule34VideoUrlActivity.kt
@@ -1,0 +1,37 @@
+package eu.kanade.tachiyomi.animeextension.en.rule34video
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.os.Bundle
+import android.util.Log
+import kotlin.system.exitProcess
+
+class Rule34VideoUrlActivity : Activity() {
+
+    private val tag = "Rule34VideoUrlActivity"
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val pathSegments = intent?.data?.pathSegments
+        if (pathSegments != null && pathSegments.size > 0) {
+            val slug = pathSegments[2]
+            val mainIntent = Intent().apply {
+                action = "eu.kanade.tachiyomi.ANIMESEARCH"
+                putExtra("query", "${Rule34Video.PREFIX_SEARCH}$slug")
+                putExtra("filter", packageName)
+            }
+
+            try {
+                startActivity(mainIntent)
+            } catch (e: ActivityNotFoundException) {
+                Log.e(tag, e.toString())
+            }
+        } else {
+            Log.e(tag, "could not parse uri from intent $intent")
+        }
+
+        finish()
+        exitProcess(0)
+    }
+}


### PR DESCRIPTION
Fixed Search
Added support Url Activity. Now user can open rule34video.com links in aniyomi.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
