### PR TITLE
fix(en/kickassanime): fix for episodes without titles

### DIFF
--- a/src/en/kickassanime/build.gradle
+++ b/src/en/kickassanime/build.gradle
@@ -9,7 +9,7 @@ ext {
     pkgNameSuffix = 'en.kickassanime'
     extClass = '.KickAssAnime'
     libVersion = '13'
-    extVersionCode = 30
+    extVersionCode = 31
 }
 
 dependencies {

--- a/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/dto/KickAssAnimeDto.kt
+++ b/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/dto/KickAssAnimeDto.kt
@@ -56,7 +56,7 @@ data class EpisodeResponseDto(
     @Serializable
     data class EpisodeDto(
         val slug: String,
-        val title: String,
+        val title: String? = "",
         val episode_string: String,
     )
 }


### PR DESCRIPTION
Closes  #1934

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
