### PR TITLE
fix(en/kickassanime): fix video headers

### DIFF
--- a/src/en/kickassanime/build.gradle
+++ b/src/en/kickassanime/build.gradle
@@ -9,7 +9,7 @@ ext {
     pkgNameSuffix = 'en.kickassanime'
     extClass = '.KickAssAnime'
     libVersion = '13'
-    extVersionCode = 31
+    extVersionCode = 32
 }
 
 dependencies {

--- a/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/extractors/KickAssAnimeExtractor.kt
+++ b/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/extractors/KickAssAnimeExtractor.kt
@@ -102,10 +102,26 @@ class KickAssAnimeExtractor(
             Track(subUrl, language)
         }
 
+        fun getVideoHeaders(baseHeaders: Headers, referer: String, videoUrl: String): Headers {
+            return baseHeaders.newBuilder().apply {
+                add("Accept", "*/*")
+                add("Accept-Language", "en-US,en;q=0.5")
+                add("Origin", "https://$host")
+                add("Sec-Fetch-Dest", "empty")
+                add("Sec-Fetch-Mode", "cors")
+                add("Sec-Fetch-Site", "cross-site")
+            }.build()
+        }
+
         return when {
             videoObject.hls.isBlank() ->
                 PlaylistUtils(client, headers).extractFromDash(videoObject.playlistUrl, videoNameGen = { res -> "$name - $res" }, subtitleList = subtitles)
-            else -> PlaylistUtils(client, headers).extractFromHls(videoObject.playlistUrl, videoNameGen = { "$name - $it" }, subtitleList = subtitles)
+            else -> PlaylistUtils(client, headers).extractFromHls(
+                videoObject.playlistUrl,
+                videoNameGen = { "$name - $it" },
+                videoHeadersGen = ::getVideoHeaders,
+                subtitleList = subtitles,
+            )
         }
     }
 


### PR DESCRIPTION
Closes #1994

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
