### PR TITLE
Fixes order of latest updates (Gogoanime)

### DIFF
--- a/src/en/gogoanime/build.gradle
+++ b/src/en/gogoanime/build.gradle
@@ -7,7 +7,7 @@ ext {
     extName = 'Gogoanime'
     pkgNameSuffix = 'en.gogoanime'
     extClass = '.GogoAnime'
-    extVersionCode = 70
+    extVersionCode = 71
     libVersion = '13'
 }
 

--- a/src/en/gogoanime/src/eu/kanade/tachiyomi/animeextension/en/gogoanime/GogoAnime.kt
+++ b/src/en/gogoanime/src/eu/kanade/tachiyomi/animeextension/en/gogoanime/GogoAnime.kt
@@ -72,14 +72,13 @@ class GogoAnime : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
     // =============================== Latest ===============================
 
     override fun latestUpdatesRequest(page: Int): Request =
-        GET("https://ajax.gogo-load.com/ajax/page-recent-release-ongoing.html?page=$page&type=1", headers)
+        GET("$baseUrl/?page=$page", headers)
 
-    override fun latestUpdatesSelector(): String = "div.added_series_body.popular li a:has(div)"
+    override fun latestUpdatesSelector(): String = "div.img a"
 
     override fun latestUpdatesFromElement(element: Element): SAnime = SAnime.create().apply {
-        setUrlWithoutDomain(element.attr("abs:href"))
-        thumbnail_url = element.select("div.thumbnail-popular").attr("style")
-            .substringAfter("background: url('").substringBefore("');")
+        setUrlWithoutDomain(element.attr("href"))
+        thumbnail_url = element.selectFirst("img")!!.attr("src")
         title = element.attr("title")
     }
 
@@ -253,7 +252,7 @@ class GogoAnime : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
         private val PREF_DOMAIN_KEY = "preferred_domain_name_v${AppInfo.getVersionName()}"
         private const val PREF_DOMAIN_TITLE = "Override BaseUrl"
-        private const val PREF_DOMAIN_DEFAULT = "https://gogoanime3.net"
+        private const val PREF_DOMAIN_DEFAULT = "https://gogoanimehd.to"
         private const val PREF_DOMAIN_SUMMARY = "For temporary uses. Updating the extension will erase this setting."
 
         private const val PREF_QUALITY_KEY = "preferred_quality"


### PR DESCRIPTION
The order of recently updated wasn't the same as the website so I did a small fix. Also I changed the baseUrl as the old one didn't have an ssl certificate anymore so I felt that they might change that domain soon.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
