### PR TITLE
Fetch Anilist Cover (OppaiStream)

### DIFF
--- a/src/en/oppaistream/build.gradle
+++ b/src/en/oppaistream/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Oppai Stream'
     pkgNameSuffix = 'en.oppaistream'
     extClass = '.OppaiStream'
-    extVersionCode = 1
+    extVersionCode = 2
     containsNsfw = true
 }
 


### PR DESCRIPTION
This functionality retrieves covers from AniList by matching titles and studio names, specifically within the anime details page. This approach is taken to avoid timeout errors resulting from the AniList API limits that would occur if attempting to fetch covers in the searchAnimeFromElement.

Default cover image are just screenshot thumbnails thats why using AniList covers


Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
