### PR TITLE
refactor: Specify the libVersion parameter in some extensions

### DIFF
--- a/multisrc/src/main/java/generator/ThemeSourceGenerator.kt
+++ b/multisrc/src/main/java/generator/ThemeSourceGenerator.kt
@@ -69,9 +69,11 @@ interface ThemeSourceGenerator {
             gradle.writeText(
                 """
                 |// THIS FILE IS AUTO-GENERATED; DO NOT EDIT
-                |apply plugin: 'com.android.application'
-                |apply plugin: 'kotlin-android'
-                |apply plugin: 'kotlinx-serialization'
+                |plugins {
+                |    alias(libs.plugins.android.application)
+                |    alias(libs.plugins.kotlin.android)
+                |    alias(libs.plugins.kotlin.serialization)
+                |}
                 |
                 |ext {
                 |    extName = '${source.name}'
@@ -79,6 +81,7 @@ interface ThemeSourceGenerator {
                 |    extClass = '.${source.className}'
                 |    extFactory = '$themePkg'
                 |    extVersionCode = ${baseVersionCode + source.overrideVersionCode + MULTISRC_LIBRARY_VERSION}
+                |    libVersion = '13'
                 |    ${if (source.isNsfw) "containsNsfw = true\n" else ""}
                 |}
                 |$defaultAdditionalGradleText

--- a/src/all/javguru/build.gradle
+++ b/src/all/javguru/build.gradle
@@ -8,6 +8,7 @@ ext {
     pkgNameSuffix = 'all.javguru'
     extClass = '.JavGuru'
     extVersionCode = 4
+    libVersion = '13'
     containsNsfw = true
 }
 

--- a/src/ar/okanime/build.gradle
+++ b/src/ar/okanime/build.gradle
@@ -8,6 +8,7 @@ ext {
     pkgNameSuffix = 'ar.okanime'
     extClass = '.Okanime'
     extVersionCode = 2
+    libVersion = '13'
 }
 
 dependencies {

--- a/src/en/oppaistream/build.gradle
+++ b/src/en/oppaistream/build.gradle
@@ -1,11 +1,14 @@
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
+plugins {
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
+}
 
 ext {
     extName = 'Oppai Stream'
     pkgNameSuffix = 'en.oppaistream'
     extClass = '.OppaiStream'
     extVersionCode = 2
+    libVersion = '13'
     containsNsfw = true
 }
 

--- a/src/id/nimegami/build.gradle
+++ b/src/id/nimegami/build.gradle
@@ -9,6 +9,7 @@ ext {
     pkgNameSuffix = 'id.nimegami'
     extClass = '.NimeGami'
     extVersionCode = 1
+    libVersion = '13'
 }
 
 dependencies {

--- a/src/pt/anidong/build.gradle
+++ b/src/pt/anidong/build.gradle
@@ -9,6 +9,7 @@ ext {
     pkgNameSuffix = 'pt.anidong'
     extClass = '.AniDong'
     extVersionCode = 1
+    libVersion = '13'
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/animesaria/build.gradle
+++ b/src/pt/animesaria/build.gradle
@@ -8,6 +8,7 @@ ext {
     pkgNameSuffix = 'pt.animesaria'
     extClass = '.AnimesAria'
     extVersionCode = 2
+    libVersion = '13'
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/animesdigital/build.gradle
+++ b/src/pt/animesdigital/build.gradle
@@ -9,6 +9,7 @@ ext {
     pkgNameSuffix = 'pt.animesdigital'
     extClass = '.AnimesDigital'
     extVersionCode = 1
+    libVersion = '13'
 }
 
 dependencies {

--- a/src/pt/animesgames/build.gradle
+++ b/src/pt/animesgames/build.gradle
@@ -9,6 +9,7 @@ ext {
     pkgNameSuffix = 'pt.animesgames'
     extClass = '.AnimesGames'
     extVersionCode = 1
+    libVersion = '13'
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/animesorion/build.gradle
+++ b/src/pt/animesorion/build.gradle
@@ -8,6 +8,7 @@ ext {
     pkgNameSuffix = 'pt.animesorion'
     extClass = '.AnimesOrion'
     extVersionCode = 1
+    libVersion = '13'
     containsNsfw = true
 }
 

--- a/src/pt/animestc/build.gradle
+++ b/src/pt/animestc/build.gradle
@@ -9,6 +9,7 @@ ext {
     pkgNameSuffix = 'pt.animestc'
     extClass = '.AnimesTC'
     extVersionCode = 2
+    libVersion = '13'
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/donghuanosekai/build.gradle
+++ b/src/pt/donghuanosekai/build.gradle
@@ -9,6 +9,7 @@ ext {
     pkgNameSuffix = 'pt.donghuanosekai'
     extClass = '.DonghuaNoSekai'
     extVersionCode = 2
+    libVersion = '13'
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/flixei/build.gradle
+++ b/src/pt/flixei/build.gradle
@@ -9,6 +9,7 @@ ext {
     pkgNameSuffix = 'pt.flixei'
     extClass = '.Flixei'
     extVersionCode = 1
+    libVersion = '13'
 }
 
 dependencies {

--- a/src/pt/hentaistube/build.gradle
+++ b/src/pt/hentaistube/build.gradle
@@ -9,6 +9,7 @@ ext {
     pkgNameSuffix = 'pt.hentaistube'
     extClass = '.HentaisTube'
     extVersionCode = 1
+    libVersion = '13'
     containsNsfw = true
 }
 

--- a/src/pt/listadeanimes/build.gradle
+++ b/src/pt/listadeanimes/build.gradle
@@ -1,13 +1,14 @@
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
+plugins {
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
+}
 
 ext {
     extName = 'Lista de Animes'
     pkgNameSuffix = 'pt.listadeanimes'
     extClass = '.ListaDeAnimes'
     extVersionCode = 2
-    libversion = '13'
-    containsNsfw = false
+    libVersion = '13'
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/megaflix/build.gradle
+++ b/src/pt/megaflix/build.gradle
@@ -8,6 +8,7 @@ ext {
     pkgNameSuffix = 'pt.megaflix'
     extClass = '.Megaflix'
     extVersionCode = 6
+    libVersion = '13'
     containsNsfw = true
 }
 

--- a/src/pt/meusanimes/build.gradle
+++ b/src/pt/meusanimes/build.gradle
@@ -8,6 +8,7 @@ ext {
     pkgNameSuffix = 'pt.meusanimes'
     extClass = '.MeusAnimes'
     extVersionCode = 2
+    libVersion = '13'
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/sr/animesrbija/build.gradle
+++ b/src/sr/animesrbija/build.gradle
@@ -9,6 +9,7 @@ ext {
     pkgNameSuffix = 'sr.animesrbija'
     extClass = '.AnimeSrbija'
     extVersionCode = 5
+    libVersion = '13'
 }
 
 dependencies {


### PR DESCRIPTION
Just to prevent some issues when upgrading to future versions of the `extensions-lib`.

Hmmmm, i wonder who made most of those sources without the `libVersion` parameter.....