### PR TITLE
fix(tr/anizm): Fix UQLoad extractor

### DIFF
--- a/src/tr/anizm/build.gradle
+++ b/src/tr/anizm/build.gradle
@@ -8,7 +8,7 @@ ext {
     extName = 'Anizm'
     pkgNameSuffix = 'tr.anizm'
     extClass = '.Anizm'
-    extVersionCode = 1
+    extVersionCode = 2
     libVersion = '13'
 }
 

--- a/src/tr/anizm/src/eu/kanade/tachiyomi/animeextension/tr/anizm/extractors/UQLoadExtractor.kt
+++ b/src/tr/anizm/src/eu/kanade/tachiyomi/animeextension/tr/anizm/extractors/UQLoadExtractor.kt
@@ -3,6 +3,7 @@ package eu.kanade.tachiyomi.animeextension.tr.anizm.extractors
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.util.asJsoup
+import okhttp3.Headers
 import okhttp3.OkHttpClient
 
 class UQLoadExtractor(private val client: OkHttpClient) {
@@ -12,6 +13,7 @@ class UQLoadExtractor(private val client: OkHttpClient) {
             ?: return null
         val videoUrl = check.substringAfter("sources: [\"", "").substringBefore("\"", "")
         if (videoUrl.isBlank()) return null
-        return Video(videoUrl, quality, videoUrl)
+        val videoHeaders = Headers.headersOf("Referer", url)
+        return Video(videoUrl, quality, videoUrl, videoHeaders)
     }
 }


### PR DESCRIPTION
Closes #2138 
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Have not changed source names
- [x] Have tested the modifications by compiling and running the extension through Android Studio
