### PR TITLE
Fixes webview url of gogoanime for latest updates

### DIFF
--- a/src/en/gogoanime/build.gradle
+++ b/src/en/gogoanime/build.gradle
@@ -7,7 +7,7 @@ ext {
     extName = 'Gogoanime'
     pkgNameSuffix = 'en.gogoanime'
     extClass = '.GogoAnime'
-    extVersionCode = 71
+    extVersionCode = 72
     libVersion = '13'
 }
 

--- a/src/en/gogoanime/src/eu/kanade/tachiyomi/animeextension/en/gogoanime/GogoAnime.kt
+++ b/src/en/gogoanime/src/eu/kanade/tachiyomi/animeextension/en/gogoanime/GogoAnime.kt
@@ -76,10 +76,26 @@ class GogoAnime : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override fun latestUpdatesSelector(): String = "div.img a"
 
-    override fun latestUpdatesFromElement(element: Element): SAnime = SAnime.create().apply {
-        setUrlWithoutDomain(element.attr("href"))
-        thumbnail_url = element.selectFirst("img")!!.attr("src")
-        title = element.attr("title")
+    override fun latestUpdatesFromElement(element: Element): SAnime {
+        val imgUrl = element.selectFirst("img")!!.attr("src")
+
+        val newUrl = imgUrl.replaceFirst("https://", "").substringAfter("/").replaceFirst("cover", "/category").substringBeforeLast('.')
+
+        val finalUrl = newUrl.let { url ->
+            url.lastIndexOf('-').let { lastIndex ->
+                val suffix = url.substring(lastIndex + 1)
+                if (lastIndex == -1 || !suffix.all { it.isDigit() } || suffix.length < 3) {
+                    newUrl
+                } else {
+                    url.substring(0, lastIndex)
+                }
+            }
+        }
+        return SAnime.create().apply {
+            setUrlWithoutDomain(finalUrl)
+            thumbnail_url = element.selectFirst("img")!!.attr("src")
+            title = element.attr("title")
+        }
     }
 
     override fun latestUpdatesNextPageSelector(): String = popularAnimeNextPageSelector()


### PR DESCRIPTION
The issue was when browsing anime in the latest section and then clicking the Webview of  the anime, instead of navigating to the anime details page it navigates to the latest episode page.
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
