### PR TITLE
fix(en/kickassanime): open correct page on webview

### DIFF
--- a/src/en/kickassanime/build.gradle
+++ b/src/en/kickassanime/build.gradle
@@ -9,7 +9,7 @@ ext {
     pkgNameSuffix = 'en.kickassanime'
     extClass = '.KickAssAnime'
     libVersion = '13'
-    extVersionCode = 32
+    extVersionCode = 33
 }
 
 dependencies {

--- a/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/KickAssAnime.kt
+++ b/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/KickAssAnime.kt
@@ -151,7 +151,17 @@ class KickAssAnime : ConfigurableAnimeSource, AnimeHttpSource() {
     // tested with extensions-lib:9d3dcb0
     // override fun getAnimeUrl(anime: SAnime) = "$baseUrl${anime.url}"
 
-    override fun animeDetailsRequest(anime: SAnime) = GET("$apiUrl${anime.url}")
+    override fun animeDetailsRequest(anime: SAnime): Request = GET(baseUrl + anime.url)
+
+    override fun fetchAnimeDetails(anime: SAnime): Observable<SAnime> {
+        return client.newCall(animeDetailsRequestInternal(anime))
+            .asObservableSuccess()
+            .map { response ->
+                animeDetailsParse(response).apply { initialized = true }
+            }
+    }
+
+    private fun animeDetailsRequestInternal(anime: SAnime) = GET(apiUrl + anime.url)
 
     override fun animeDetailsParse(response: Response): SAnime {
         val languages = client.newCall(


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio

@Programmer-0-0 the problem is that WebView calls the `animeDetailsRequest` function to get the url, and the extension needed that to be the api url. The solution is simple, albeit hacky, just override `fetchAnimeDetails` to use another function to get the url, and let `animeDetailsRequest` retrieve the url to show in webview