### PR TITLE
fix(en/animeowl): Update baseUrl

### DIFF
--- a/src/en/animeowl/build.gradle
+++ b/src/en/animeowl/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'AnimeOwl'
     pkgNameSuffix = 'en.animeowl'
     extClass = '.AnimeOwl'
-    extVersionCode = 13
+    extVersionCode = 14
     libVersion = '13'
 }
 

--- a/src/en/animeowl/src/eu/kanade/tachiyomi/animeextension/en/animeowl/AnimeOwl.kt
+++ b/src/en/animeowl/src/eu/kanade/tachiyomi/animeextension/en/animeowl/AnimeOwl.kt
@@ -46,7 +46,7 @@ class AnimeOwl : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override val name = "AnimeOwl"
 
-    override val baseUrl by lazy { preferences.getString("preferred_domain", "https://animeowl.net")!! }
+    override val baseUrl by lazy { preferences.getString("preferred_domain", "https://anime-owl.net")!! }
 
     override val lang = "en"
 

--- a/src/en/animeowl/src/eu/kanade/tachiyomi/animeextension/en/animeowl/AnimeOwl.kt
+++ b/src/en/animeowl/src/eu/kanade/tachiyomi/animeextension/en/animeowl/AnimeOwl.kt
@@ -46,7 +46,7 @@ class AnimeOwl : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override val name = "AnimeOwl"
 
-    override val baseUrl by lazy { preferences.getString("preferred_domain", "https://anime-owl.net")!! }
+    override val baseUrl = "https://anime-owl.net"
 
     override val lang = "en"
 
@@ -334,21 +334,6 @@ class AnimeOwl : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
     }
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
-        val domainPref = ListPreference(screen.context).apply {
-            key = "preferred_domain"
-            title = "Preferred domain (requires app restart)"
-            entries = arrayOf("animeowl.net")
-            entryValues = arrayOf("https://animeowl.net")
-            setDefaultValue("https://animeowl.net")
-            summary = "%s"
-
-            setOnPreferenceChangeListener { _, newValue ->
-                val selected = newValue as String
-                val index = findIndexOfValue(selected)
-                val entry = entryValues[index] as String
-                preferences.edit().putString(key, entry).commit()
-            }
-        }
         val videoQualityPref = ListPreference(screen.context).apply {
             key = "preferred_quality"
             title = "Preferred quality"
@@ -379,7 +364,6 @@ class AnimeOwl : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
                 preferences.edit().putString(key, entry).commit()
             }
         }
-        screen.addPreference(domainPref)
         screen.addPreference(videoQualityPref)
         screen.addPreference(videoLangPref)
     }


### PR DESCRIPTION
Closes https://github.com/aniyomiorg/aniyomi-extensions/issues/2189

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
