### PR TITLE
fix(multisrc/dopeflix): Fix DopeFlix filters

### DIFF
--- a/multisrc/overrides/dopeflix/default/additional.gradle
+++ b/multisrc/overrides/dopeflix/default/additional.gradle
@@ -1,4 +1,5 @@
 dependencies {
     implementation(project(":lib-dood-extractor"))
     implementation(project(":lib-cryptoaes"))
+    implementation(project(":lib-playlist-utils"))
 }

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/dopeflix/DopeFlix.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/dopeflix/DopeFlix.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
 import okhttp3.Headers
+import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -94,13 +95,13 @@ abstract class DopeFlix(
             val fixedQuery = query.replace(" ", "-")
             "$baseUrl/search/$fixedQuery?page=$page"
         } else {
-            "$baseUrl/filter?".toHttpUrl().newBuilder()
+            "$baseUrl/filter".toHttpUrl().newBuilder()
                 .addQueryParameter("page", page.toString())
                 .addQueryParameter("type", params.type)
                 .addQueryParameter("quality", params.quality)
                 .addQueryParameter("release_year", params.releaseYear)
-                .addQueryParameter("genre", params.genres)
-                .addQueryParameter("country", params.countries)
+                .addIfNotBlank("genre", params.genres)
+                .addIfNotBlank("country", params.countries)
                 .build()
                 .toString()
         }
@@ -345,6 +346,13 @@ abstract class DopeFlix(
         runBlocking {
             map { async(Dispatchers.Default) { f(it) } }.awaitAll()
         }
+
+    private fun HttpUrl.Builder.addIfNotBlank(query: String, value: String): HttpUrl.Builder {
+        if (value.isNotBlank()) {
+            addQueryParameter(query, value)
+        }
+        return this
+    }
 
     companion object {
         private const val PREF_DOMAIN_KEY = "preferred_domain_new"

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/dopeflix/DopeFlixGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/dopeflix/DopeFlixGenerator.kt
@@ -8,7 +8,7 @@ class DopeFlixGenerator : ThemeSourceGenerator {
 
     override val themeClass = "DopeFlix"
 
-    override val baseVersionCode = 18
+    override val baseVersionCode = 19
 
     override val sources = listOf(
         SingleLang("DopeBox", "https://dopebox.to", "en", isNsfw = false, overrideVersionCode = 2),


### PR DESCRIPTION
Closes #2222 
Checklist:

- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
