### PR TITLE
fix(pt/animesdigital): Fetch all episodes on multi-page animes

### DIFF
--- a/src/pt/animesdigital/build.gradle
+++ b/src/pt/animesdigital/build.gradle
@@ -8,7 +8,7 @@ ext {
     extName = 'Animes Digital'
     pkgNameSuffix = 'pt.animesdigital'
     extClass = '.AnimesDigital'
-    extVersionCode = 1
+    extVersionCode = 2
     libVersion = '13'
 }
 

--- a/src/pt/animesdigital/src/eu/kanade/tachiyomi/animeextension/pt/animesdigital/AnimesDigital.kt
+++ b/src/pt/animesdigital/src/eu/kanade/tachiyomi/animeextension/pt/animesdigital/AnimesDigital.kt
@@ -59,16 +59,13 @@ class AnimesDigital : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
         val doc = getRealDoc(response.asJsoup())
         val pagination = doc.selectFirst("ul.content-pagination")
         return if (pagination != null) {
-            val episodes = emptyList<SEpisode>().toMutableList()
+            val episodes = mutableListOf<SEpisode>()
             episodes += doc.select(episodeListSelector()).map(::episodeFromElement)
             val lastPage = doc.selectFirst("ul.content-pagination > li:nth-last-child(2) > span")!!.text().toInt()
             for (i in 2..lastPage) {
-                val request = Request.Builder()
-                    .url(response.request.url.toString() + "/page/$i")
-                    .addHeader("Referer", baseUrl)
-                    .build()
+                val request = GET(doc.location() + "/page/$i", headers)
                 val res = client.newCall(request).execute()
-                val pageDoc = getRealDoc(res.asJsoup())
+                val pageDoc = res.use { it.asJsoup() }
                 episodes += pageDoc.select(episodeListSelector()).map(::episodeFromElement)
             }
             episodes


### PR DESCRIPTION
AnimesDigital shows multiples pages of episodes of the anime when there's more than 25 episodes. The extension was only fetching the first page.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
