### PR TITLE
feat(hi/yomovies): Add Minoplres extractor

### DIFF
--- a/src/hi/yomovies/build.gradle
+++ b/src/hi/yomovies/build.gradle
@@ -1,11 +1,13 @@
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
+plugins {
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
+}
 
 ext {
     extName = 'YoMovies'
     pkgNameSuffix = 'hi.yomovies'
     extClass = '.YoMovies'
-    extVersionCode = 2
+    extVersionCode = 3
     libVersion = '13'
     containsNsfw = true
 }

--- a/src/hi/yomovies/src/eu/kanade/tachiyomi/animeextension/hi/yomovies/extractors/MinoplresExtractor.kt
+++ b/src/hi/yomovies/src/eu/kanade/tachiyomi/animeextension/hi/yomovies/extractors/MinoplresExtractor.kt
@@ -1,0 +1,27 @@
+package eu.kanade.tachiyomi.animeextension.hi.yomovies.extractors
+
+import eu.kanade.tachiyomi.animesource.model.Video
+import eu.kanade.tachiyomi.lib.playlistutils.PlaylistUtils
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.util.asJsoup
+import okhttp3.Headers
+import okhttp3.OkHttpClient
+
+class MinoplresExtractor(private val client: OkHttpClient, private val headers: Headers) {
+    private val playlistUtils by lazy { PlaylistUtils(client, headers) }
+
+    fun videosFromUrl(url: String, name: String): List<Video> {
+        val newHeaders = headers.newBuilder().set("Referer", url).build()
+        val doc = client.newCall(GET(url, newHeaders)).execute()
+            .use { it.asJsoup() }
+        val script = doc.selectFirst("script:containsData(sources:)")?.data()
+            ?: return emptyList()
+
+        val masterUrl = script.substringAfter("file:\"").substringBefore('"')
+        return playlistUtils.extractFromHls(
+            masterUrl,
+            referer = url,
+            videoNameGen = { "$name Minoplres - $it" },
+        )
+    }
+}

--- a/src/hi/yomovies/src/eu/kanade/tachiyomi/animeextension/hi/yomovies/extractors/MovembedExtractor.kt
+++ b/src/hi/yomovies/src/eu/kanade/tachiyomi/animeextension/hi/yomovies/extractors/MovembedExtractor.kt
@@ -50,7 +50,7 @@ class MovembedExtractor(private val client: OkHttpClient, private val headers: H
     }
 
     // From Dopebox
-    private fun <A, B> Iterable<A>.parallelMap(f: suspend (A) -> B): List<B> =
+    private inline fun <A, B> Iterable<A>.parallelMap(crossinline f: suspend (A) -> B): List<B> =
         runBlocking {
             map { async(Dispatchers.Default) { f(it) } }.awaitAll()
         }


### PR DESCRIPTION
Closes #2254
^ Because now most episodes only have Minoplres and Netu as video hosters, and i'll leave the Netu extractor to Secozzi 👍🏽 
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Have not changed source names
- [x] Have tested the modifications by compiling and running the extension through Android Studio
