### PR TITLE
fix(ar/witanime): Fix soraplay & mp4upload extractors + update baseUrl

### DIFF
--- a/lib/mp4upload-extractor/src/main/java/eu/kanade/tachiyomi/lib/mp4uploadextractor/Mp4uploadExtractor.kt
+++ b/lib/mp4upload-extractor/src/main/java/eu/kanade/tachiyomi/lib/mp4uploadextractor/Mp4uploadExtractor.kt
@@ -10,7 +10,7 @@ import dev.datlag.jsunpacker.JsUnpacker
 class Mp4uploadExtractor(private val client: OkHttpClient) {
     fun videosFromUrl(url: String, headers: Headers, prefix: String = "", suffix: String = ""): List<Video> {
         val newHeaders = headers.newBuilder()
-            .add("referer", REFERER)
+            .set("referer", REFERER)
             .build()
 
         val doc = client.newCall(GET(url, newHeaders)).execute().use { it.asJsoup() }

--- a/src/ar/witanime/build.gradle
+++ b/src/ar/witanime/build.gradle
@@ -7,7 +7,7 @@ ext {
     extName = 'WIT ANIME'
     pkgNameSuffix = 'ar.witanime'
     extClass = '.WitAnime'
-    extVersionCode = 44
+    extVersionCode = 45
     libVersion = '13'
 }
 

--- a/src/ar/witanime/src/eu/kanade/tachiyomi/animeextension/ar/witanime/extractors/SoraPlayExtractor.kt
+++ b/src/ar/witanime/src/eu/kanade/tachiyomi/animeextension/ar/witanime/extractors/SoraPlayExtractor.kt
@@ -8,14 +8,15 @@ import okhttp3.OkHttpClient
 
 class SoraPlayExtractor(private val client: OkHttpClient) {
     fun videosFromUrl(url: String, headers: Headers): List<Video> {
-        val doc = client.newCall(GET(url)).execute().asJsoup()
+        val newHeaders = headers.newBuilder().set("referer", "https://yonaplay.org/").build()
+        val doc = client.newCall(GET(url, newHeaders)).execute().asJsoup()
         val script = doc.selectFirst("script:containsData(sources)")!!
         val data = script.data().substringAfter("sources: [").substringBefore("],")
 
         return data.split("\"file\":\"").drop(1).map { source ->
             val src = source.substringBefore("\"")
             val quality = "Soraplay: " + source.substringAfter("\"label\":\"").substringBefore("\"")
-            Video(src, quality, src, headers = headers)
+            Video(src, quality, src, headers = newHeaders)
         }
     }
 }


### PR DESCRIPTION
Closes #2290 
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Have not changed source names
- [x] Have tested the modifications by compiling and running the extension through Android Studio
