### PR TITLE
fix(en/aniwave): Upload date parsing

### DIFF
--- a/src/en/aniwave/build.gradle
+++ b/src/en/aniwave/build.gradle
@@ -8,7 +8,7 @@ ext {
     extName = 'Aniwave'
     pkgNameSuffix = 'en.nineanime'
     extClass = '.Aniwave'
-    extVersionCode = 54
+    extVersionCode = 55
     libVersion = '13'
 }
 

--- a/src/en/aniwave/src/eu/kanade/tachiyomi/animeextension/en/nineanime/Aniwave.kt
+++ b/src/en/aniwave/src/eu/kanade/tachiyomi/animeextension/en/nineanime/Aniwave.kt
@@ -301,6 +301,7 @@ class Aniwave : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
         )
     }
 
+    @Synchronized
     private fun parseDate(dateStr: String): Long {
         return runCatching { DATE_FORMATTER.parse(dateStr)?.time }
             .getOrNull() ?: 0L


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
