### PR TITLE
fix(all/lmanime): Fix video extractor

### DIFF
--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/animestream/AnimeStreamGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/animestream/AnimeStreamGenerator.kt
@@ -21,7 +21,7 @@ class AnimeStreamGenerator : ThemeSourceGenerator {
         SingleLang("desu-online", "https://desu-online.pl", "pl", className = "DesuOnline", isNsfw = false, overrideVersionCode = 3),
         SingleLang("DonghuaStream", "https://donghuastream.co.in", "en", isNsfw = false, overrideVersionCode = 2),
         SingleLang("Hstream", "https://hstream.moe", "en", isNsfw = true, overrideVersionCode = 3),
-        SingleLang("LMAnime", "https://lmanime.com", "all", isNsfw = false, overrideVersionCode = 3),
+        SingleLang("LMAnime", "https://lmanime.com", "all", isNsfw = false, overrideVersionCode = 4),
         SingleLang("LuciferDonghua", "https://luciferdonghua.in", "en", isNsfw = false, overrideVersionCode = 2),
         SingleLang("MiniOppai", "https://minioppai.org", "id", isNsfw = true, overrideVersionCode = 2),
         SingleLang("RineCloud", "https://rine.cloud", "pt-BR", isNsfw = false, overrideVersionCode = 3),


### PR DESCRIPTION
Closes #2395 
Checklist:

- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Have not changed source names
- [x] Have tested the modifications by compiling and running the extension through Android Studio
