### PR TITLE
chore: fix pref key for overridable baseurls

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -73,6 +73,7 @@ android {
         renderScript false
         resValues false
         shaders false
+        buildConfig true
     }
 
     compileOptions {

--- a/multisrc/overrides/dooplay/multimovies/src/Multimovies.kt
+++ b/multisrc/overrides/dooplay/multimovies/src/Multimovies.kt
@@ -6,7 +6,7 @@ import android.widget.Toast
 import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
-import eu.kanade.tachiyomi.AppInfo
+import eu.kanade.tachiyomi.animeextension.BuildConfig
 import eu.kanade.tachiyomi.animeextension.en.multimovies.extractors.AutoEmbedExtractor
 import eu.kanade.tachiyomi.animeextension.en.multimovies.extractors.MultimoviesCloudExtractor
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
@@ -28,11 +28,11 @@ import uy.kohesive.injekt.api.get
 class Multimovies : DooPlay(
     "en",
     "Multimovies",
-    "https://multimovies.shop",
+    "https://multimovies.live",
 ) {
     override val client = network.cloudflareClient
 
-    private val defaultBaseUrl = "https://multimovies.shop"
+    private val defaultBaseUrl = "https://multimovies.live"
 
     override val baseUrl by lazy { getPrefBaseUrl() }
 
@@ -199,7 +199,7 @@ class Multimovies : DooPlay(
     companion object {
         private const val RESTART_ANIYOMI = "Restart Aniyomi to apply new setting."
         private const val BASE_URL_PREF_TITLE = "Override BaseUrl"
-        private val BASE_URL_PREF = "overrideBaseUrl_v${AppInfo.getVersionName()}"
+        private val BASE_URL_PREF = "overrideBaseUrl_v${BuildConfig.VERSION_CODE}"
         private const val BASE_URL_PREF_SUMMARY = "For temporary uses. Updating the extension will erase this setting."
 
         private const val PREF_SERVER_KEY = "preferred_server"

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/dooplay/DooPlayGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/dooplay/DooPlayGenerator.kt
@@ -23,7 +23,7 @@ class DooPlayGenerator : ThemeSourceGenerator {
         SingleLang("GoAnimes", "https://goanimes.net", "pt-BR", isNsfw = true, overrideVersionCode = 5),
         SingleLang("JetAnime", "https://ssl.jetanimes.com", "fr", isNsfw = false, overrideVersionCode = 2),
         SingleLang("Kinoking", "https://kinoking.cc", "de", isNsfw = false, overrideVersionCode = 17),
-        SingleLang("Multimovies", "https://multimovies.shop", "en", isNsfw = false, overrideVersionCode = 11),
+        SingleLang("Multimovies", "https://multimovies.live", "en", isNsfw = false, overrideVersionCode = 12),
         SingleLang("Pi Fansubs", "https://pifansubs.org", "pt-BR", isNsfw = true, overrideVersionCode = 17),
         SingleLang("Pobreflix", "https://pobreflix.biz", "pt-BR", isNsfw = true, overrideVersionCode = 1),
         SingleLang("UniqueStream", "https://uniquestream.net", "en", isNsfw = false, overrideVersionCode = 2),

--- a/src/en/aniwave/build.gradle
+++ b/src/en/aniwave/build.gradle
@@ -8,7 +8,7 @@ ext {
     extName = 'Aniwave'
     pkgNameSuffix = 'en.nineanime'
     extClass = '.Aniwave'
-    extVersionCode = 56
+    extVersionCode = 57
     libVersion = '13'
 }
 

--- a/src/en/aniwave/src/eu/kanade/tachiyomi/animeextension/en/nineanime/AniwaveUtils.kt
+++ b/src/en/aniwave/src/eu/kanade/tachiyomi/animeextension/en/nineanime/AniwaveUtils.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.animeextension.en.nineanime
 
 import eu.kanade.tachiyomi.AppInfo
+import eu.kanade.tachiyomi.animeextension.BuildConfig
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import kotlinx.serialization.json.Json
@@ -16,7 +17,7 @@ class AniwaveUtils(private val client: OkHttpClient, private val headers: Header
 
     private val userAgent = Headers.headersOf(
         "User-Agent",
-        "Aniyomi/${AppInfo.getVersionName()} (AniWave)",
+        "Aniyomi/${AppInfo.getVersionName()} (AniWave; ${BuildConfig.VERSION_CODE})",
     )
 
     fun callEnimax(query: String, action: String): String {

--- a/src/en/ask4movie/build.gradle
+++ b/src/en/ask4movie/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'Ask4Movie'
     pkgNameSuffix = 'en.ask4movie'
     extClass = '.Ask4Movie'
-    extVersionCode = 9
+    extVersionCode = 10
     libVersion = '13'
 }
 

--- a/src/en/ask4movie/src/eu/kanade/tachiyomi/animeextension/en/ask4movie/Ask4Movie.kt
+++ b/src/en/ask4movie/src/eu/kanade/tachiyomi/animeextension/en/ask4movie/Ask4Movie.kt
@@ -5,7 +5,7 @@ import android.content.SharedPreferences
 import android.widget.Toast
 import androidx.preference.EditTextPreference
 import androidx.preference.PreferenceScreen
-import eu.kanade.tachiyomi.AppInfo
+import eu.kanade.tachiyomi.animeextension.BuildConfig
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilter
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
@@ -197,9 +197,9 @@ class Ask4Movie : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
     }
 
     companion object {
-        private val PREF_DOMAIN_KEY = "preferred_domain_name_v${AppInfo.getVersionName()}"
+        private val PREF_DOMAIN_KEY = "preferred_domain_name_v${BuildConfig.VERSION_NAME}"
         private const val PREF_DOMAIN_TITLE = "Override BaseUrl"
-        private const val PREF_DOMAIN_DEFAULT = "https://ask4movie.nl"
+        private const val PREF_DOMAIN_DEFAULT = "https://ask4movie.li"
         private const val PREF_DOMAIN_SUMMARY = "For temporary uses. Updating the extension will erase this setting."
     }
 

--- a/src/en/dramacool/build.gradle
+++ b/src/en/dramacool/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'DramaCool'
     pkgNameSuffix = 'en.dramacool'
     extClass = '.DramaCool'
-    extVersionCode = 43
+    extVersionCode = 44
     libVersion = '13'
 }
 

--- a/src/en/dramacool/src/eu/kanade/tachiyomi/animeextension/en/dramacool/DramaCool.kt
+++ b/src/en/dramacool/src/eu/kanade/tachiyomi/animeextension/en/dramacool/DramaCool.kt
@@ -6,7 +6,7 @@ import android.widget.Toast
 import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
-import eu.kanade.tachiyomi.AppInfo
+import eu.kanade.tachiyomi.animeextension.BuildConfig
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
 import eu.kanade.tachiyomi.animesource.model.AnimesPage
@@ -34,7 +34,7 @@ class DramaCool : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override val name = "DramaCool"
 
-    private val defaultBaseUrl = "https://dramacool.hr"
+    private val defaultBaseUrl = "https://dramacool.pa"
 
     override val baseUrl by lazy { getPrefBaseUrl() }
 
@@ -218,7 +218,7 @@ class DramaCool : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
         private const val BASE_URL_PREF_TITLE = "Override BaseUrl"
 
-        private val BASE_URL_PREF = "overrideBaseUrl_v${AppInfo.getVersionName()}"
+        private val BASE_URL_PREF = "overrideBaseUrl_v${BuildConfig.VERSION_CODE}"
 
         private const val BASE_URL_PREF_SUMMARY = "For temporary uses. Update extension will erase this setting."
 

--- a/src/en/fmovies/build.gradle
+++ b/src/en/fmovies/build.gradle
@@ -8,7 +8,7 @@ ext {
     extName = 'FMovies'
     pkgNameSuffix = 'en.fmovies'
     extClass = '.FMovies'
-    extVersionCode = 13
+    extVersionCode = 14
     libVersion = '13'
 }
 

--- a/src/en/fmovies/src/eu/kanade/tachiyomi/animeextension/en/fmovies/FMoviesHelper.kt
+++ b/src/en/fmovies/src/eu/kanade/tachiyomi/animeextension/en/fmovies/FMoviesHelper.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.animeextension.en.fmovies
 
 import eu.kanade.tachiyomi.AppInfo
+import eu.kanade.tachiyomi.animeextension.BuildConfig
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import kotlinx.serialization.json.Json
@@ -18,7 +19,7 @@ class FMoviesHelper(private val client: OkHttpClient, private val headers: Heade
 
     private val userAgent = Headers.headersOf(
         "User-Agent",
-        "Aniyomi/${AppInfo.getVersionName()} (FMovies)",
+        "Aniyomi/${AppInfo.getVersionName()} (FMovies; ${BuildConfig.VERSION_CODE})",
     )
 
     fun getVrf(id: String): String {

--- a/src/en/gogoanime/build.gradle
+++ b/src/en/gogoanime/build.gradle
@@ -7,7 +7,7 @@ ext {
     extName = 'Gogoanime'
     pkgNameSuffix = 'en.gogoanime'
     extClass = '.GogoAnime'
-    extVersionCode = 75
+    extVersionCode = 76
     libVersion = '13'
 }
 

--- a/src/en/gogoanime/src/eu/kanade/tachiyomi/animeextension/en/gogoanime/GogoAnime.kt
+++ b/src/en/gogoanime/src/eu/kanade/tachiyomi/animeextension/en/gogoanime/GogoAnime.kt
@@ -7,7 +7,7 @@ import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.MultiSelectListPreference
 import androidx.preference.PreferenceScreen
-import eu.kanade.tachiyomi.AppInfo
+import eu.kanade.tachiyomi.animeextension.BuildConfig
 import eu.kanade.tachiyomi.animeextension.en.gogoanime.extractors.GogoCdnExtractor
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
@@ -266,9 +266,9 @@ class GogoAnime : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
             "filelions",
         )
 
-        private val PREF_DOMAIN_KEY = "preferred_domain_name_v${AppInfo.getVersionName()}"
+        private val PREF_DOMAIN_KEY = "preferred_domain_name_v${BuildConfig.VERSION_CODE}"
         private const val PREF_DOMAIN_TITLE = "Override BaseUrl"
-        private const val PREF_DOMAIN_DEFAULT = "https://gogoanimehd.to"
+        private const val PREF_DOMAIN_DEFAULT = "https://gogoanimehd.io"
         private const val PREF_DOMAIN_SUMMARY = "For temporary uses. Updating the extension will erase this setting."
 
         private const val PREF_QUALITY_KEY = "preferred_quality"

--- a/src/en/ripcrabbyanime/build.gradle
+++ b/src/en/ripcrabbyanime/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'Ripcrabbyanime'
     pkgNameSuffix = 'en.ripcrabbyanime'
     extClass = '.Ripcrabbyanime'
-    extVersionCode = 9
+    extVersionCode = 10
     libVersion = '13'
 }
 

--- a/src/en/ripcrabbyanime/src/eu/kanade/tachiyomi/animeextension/en/ripcrabbyanime/Ripcrabbyanime.kt
+++ b/src/en/ripcrabbyanime/src/eu/kanade/tachiyomi/animeextension/en/ripcrabbyanime/Ripcrabbyanime.kt
@@ -6,7 +6,7 @@ import android.widget.Toast
 import androidx.preference.EditTextPreference
 import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreferenceCompat
-import eu.kanade.tachiyomi.AppInfo
+import eu.kanade.tachiyomi.animeextension.BuildConfig
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilter
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
@@ -422,7 +422,7 @@ class Ripcrabbyanime : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
         private const val TRIM_EPISODE_NAME_KEY = "trim_episode"
         private const val TRIM_EPISODE_NAME_DEFAULT = true
 
-        private val PREF_DOMAIN_KEY = "preferred_domain_name_v${AppInfo.getVersionName()}"
+        private val PREF_DOMAIN_KEY = "preferred_domain_name_v${BuildConfig.VERSION_CODE}"
         private const val PREF_DOMAIN_TITLE = "Override BaseUrl"
         private const val PREF_DOMAIN_DEFAULT = "https://ripcrabbyanimes.com"
         private const val PREF_DOMAIN_SUMMARY = "For temporary uses. Updating the extension will erase this setting."

--- a/src/hi/yomovies/build.gradle
+++ b/src/hi/yomovies/build.gradle
@@ -7,7 +7,7 @@ ext {
     extName = 'YoMovies'
     pkgNameSuffix = 'hi.yomovies'
     extClass = '.YoMovies'
-    extVersionCode = 6
+    extVersionCode = 7
     libVersion = '13'
     containsNsfw = true
 }

--- a/src/hi/yomovies/src/eu/kanade/tachiyomi/animeextension/hi/yomovies/YoMovies.kt
+++ b/src/hi/yomovies/src/eu/kanade/tachiyomi/animeextension/hi/yomovies/YoMovies.kt
@@ -5,7 +5,7 @@ import android.widget.Toast
 import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
-import eu.kanade.tachiyomi.AppInfo
+import eu.kanade.tachiyomi.animeextension.BuildConfig
 import eu.kanade.tachiyomi.animeextension.hi.yomovies.extractors.MinoplresExtractor
 import eu.kanade.tachiyomi.animeextension.hi.yomovies.extractors.MovembedExtractor
 import eu.kanade.tachiyomi.animeextension.hi.yomovies.extractors.SpeedostreamExtractor
@@ -221,9 +221,9 @@ class YoMovies : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
         }
 
     companion object {
-        private val PREF_DOMAIN_KEY = "preferred_domain_name_v${AppInfo.getVersionName()}"
+        private val PREF_DOMAIN_KEY = "preferred_domain_name_v${BuildConfig.VERSION_CODE}"
         private const val PREF_DOMAIN_TITLE = "Override BaseUrl"
-        private const val PREF_DOMAIN_DEFAULT = "https://yomovies.cheap"
+        private const val PREF_DOMAIN_DEFAULT = "https://yomovies.support"
         private const val PREF_DOMAIN_SUMMARY = "For temporary uses. Updating the extension will erase this setting."
 
         private const val PREF_QUALITY_KEY = "preferred_quality"

--- a/src/it/animeunity/build.gradle
+++ b/src/it/animeunity/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'AnimeUnity'
     pkgNameSuffix = 'it.animeunity'
     extClass = '.AnimeUnity'
-    extVersionCode = 5
+    extVersionCode = 6
     libVersion = '13'
 }
 

--- a/src/it/animeunity/src/eu/kanade/tachiyomi/animeextension/it/animeunity/AnimeUnity.kt
+++ b/src/it/animeunity/src/eu/kanade/tachiyomi/animeextension/it/animeunity/AnimeUnity.kt
@@ -7,7 +7,7 @@ import android.widget.Toast
 import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
-import eu.kanade.tachiyomi.AppInfo
+import eu.kanade.tachiyomi.animeextension.BuildConfig
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
 import eu.kanade.tachiyomi.animesource.model.AnimesPage
@@ -413,9 +413,9 @@ class AnimeUnity : ConfigurableAnimeSource, AnimeHttpSource() {
     }
 
     companion object {
-        private val PREF_DOMAIN_KEY = "preferred_domain_name_v${AppInfo.getVersionName()}"
+        private val PREF_DOMAIN_KEY = "preferred_domain_name_v${BuildConfig.VERSION_CODE}"
         private const val PREF_DOMAIN_TITLE = "Override BaseUrl"
-        private const val PREF_DOMAIN_DEFAULT = "https://www.animeunity.cc"
+        private const val PREF_DOMAIN_DEFAULT = "https://www.animeunity.to"
         private const val PREF_DOMAIN_SUMMARY = "For temporary uses. Updating the extension will erase this setting."
 
         private const val PREF_QUALITY_KEY = "preferred_quality"

--- a/src/it/animeworld/build.gradle
+++ b/src/it/animeworld/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'ANIMEWORLD.tv'
     pkgNameSuffix = 'it.animeworld'
     extClass = '.ANIMEWORLD'
-    extVersionCode = 32
+    extVersionCode = 33
     libVersion = '13'
 }
 

--- a/src/it/animeworld/src/eu/kanade/tachiyomi/animeextension/it/animeworld/ANIMEWORLD.kt
+++ b/src/it/animeworld/src/eu/kanade/tachiyomi/animeextension/it/animeworld/ANIMEWORLD.kt
@@ -6,7 +6,7 @@ import android.widget.Toast
 import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
-import eu.kanade.tachiyomi.AppInfo
+import eu.kanade.tachiyomi.animeextension.BuildConfig
 import eu.kanade.tachiyomi.animeextension.it.animeworld.extractors.StreamHideExtractor
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilter
@@ -574,7 +574,7 @@ class ANIMEWORLD : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
         }
 
     companion object {
-        private val PREF_DOMAIN_KEY = "preferred_domain_name_v${AppInfo.getVersionName()}"
+        private val PREF_DOMAIN_KEY = "preferred_domain_name_v${BuildConfig.VERSION_CODE}"
         private const val PREF_DOMAIN_TITLE = "Override BaseUrl"
         private const val PREF_DOMAIN_DEFAULT = "https://www.animeworld.so"
         private const val PREF_DOMAIN_SUMMARY = "For temporary uses. Updating the extension will erase this setting."

--- a/src/it/aniplay/build.gradle
+++ b/src/it/aniplay/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'AniPlay'
     pkgNameSuffix = 'it.aniplay'
     extClass = '.AniPlay'
-    extVersionCode = 5
+    extVersionCode = 6
     libVersion = '13'
 }
 

--- a/src/it/aniplay/src/eu/kanade/tachiyomi/animeextension/it/aniplay/AniPlay.kt
+++ b/src/it/aniplay/src/eu/kanade/tachiyomi/animeextension/it/aniplay/AniPlay.kt
@@ -6,7 +6,7 @@ import android.widget.Toast
 import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
-import eu.kanade.tachiyomi.AppInfo
+import eu.kanade.tachiyomi.animeextension.BuildConfig
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
 import eu.kanade.tachiyomi.animesource.model.AnimesPage
@@ -274,7 +274,7 @@ class AniPlay : ConfigurableAnimeSource, AnimeHttpSource() {
     }
 
     companion object {
-        private val PREF_DOMAIN_KEY = "preferred_domain_name_v${AppInfo.getVersionName()}"
+        private val PREF_DOMAIN_KEY = "preferred_domain_name_v${BuildConfig.VERSION_CODE}"
         private const val PREF_DOMAIN_TITLE = "Override BaseUrl"
         private const val PREF_DOMAIN_DEFAULT = "https://aniplay.co"
         private const val PREF_DOMAIN_SUMMARY = "For temporary uses. Updating the extension will erase this setting."

--- a/src/it/streamingcommunity/build.gradle
+++ b/src/it/streamingcommunity/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'StreamingCommunity'
     pkgNameSuffix = 'it.streamingcommunity'
     extClass = '.StreamingCommunity'
-    extVersionCode = 1
+    extVersionCode = 2
     libVersion = '13'
 }
 

--- a/src/it/streamingcommunity/src/eu/kanade/tachiyomi/animeextension/it/streamingcommunity/StreamingCommunity.kt
+++ b/src/it/streamingcommunity/src/eu/kanade/tachiyomi/animeextension/it/streamingcommunity/StreamingCommunity.kt
@@ -6,7 +6,7 @@ import android.widget.Toast
 import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
-import eu.kanade.tachiyomi.AppInfo
+import eu.kanade.tachiyomi.animeextension.BuildConfig
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilter
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
@@ -346,9 +346,9 @@ class StreamingCommunity : ConfigurableAnimeSource, AnimeHttpSource() {
     }
 
     companion object {
-        private val PREF_DOMAIN_KEY = "preferred_domain_name_v${AppInfo.getVersionName()}"
+        private val PREF_DOMAIN_KEY = "preferred_domain_name_v${BuildConfig.VERSION_CODE}"
         private const val PREF_DOMAIN_TITLE = "Override BaseUrl"
-        private const val PREF_DOMAIN_DEFAULT = "https://streamingcommunity.codes"
+        private const val PREF_DOMAIN_DEFAULT = "https://streamingcommunity.at"
         private const val PREF_DOMAIN_SUMMARY = "For temporary uses. Updating the extension will erase this setting."
 
         private const val PREF_QUALITY_KEY = "preferred_quality"


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
