### PR TITLE
fix(multisrc/animestream): Make getHosterUrl function less error-prone + small fix to id/minioppai

### DIFF
--- a/multisrc/overrides/animestream/minioppai/src/extractors/MiniOppaiExtractor.kt
+++ b/multisrc/overrides/animestream/minioppai/src/extractors/MiniOppaiExtractor.kt
@@ -26,7 +26,7 @@ class MiniOppaiExtractor(private val client: OkHttpClient) {
         return scriptData.getItems("sources", baseUrl) { videoUrl, quality ->
             val videoQuality = "MiniOppai - $quality"
             Video(videoUrl, videoQuality, videoUrl, headers, subtitleTracks = subs)
-        }
+        }.filterNot { it.url.contains("/uploads/unavailable.mp4") }
     }
 
     // time to over-engineer things for no reason at all

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/animestream/AnimeStreamGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/animestream/AnimeStreamGenerator.kt
@@ -23,7 +23,7 @@ class AnimeStreamGenerator : ThemeSourceGenerator {
         SingleLang("Hstream", "https://hstream.moe", "en", isNsfw = true, overrideVersionCode = 3),
         SingleLang("LMAnime", "https://lmanime.com", "all", isNsfw = false, overrideVersionCode = 4),
         SingleLang("LuciferDonghua", "https://luciferdonghua.in", "en", isNsfw = false, overrideVersionCode = 2),
-        SingleLang("MiniOppai", "https://minioppai.org", "id", isNsfw = true, overrideVersionCode = 2),
+        SingleLang("MiniOppai", "https://minioppai.org", "id", isNsfw = true, overrideVersionCode = 3),
         SingleLang("RineCloud", "https://rine.cloud", "pt-BR", isNsfw = false, overrideVersionCode = 3),
         SingleLang("TRAnimeCI", "https://tranimeci.com", "tr", isNsfw = false),
     )


### PR DESCRIPTION
Checklist:

- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have tested the modifications by compiling and running the extension through Android Studio
