### PR TITLE
fix(en/gogoanime): Prevent low-IQ users from using a blank baseURL

### DIFF
--- a/src/en/gogoanime/build.gradle
+++ b/src/en/gogoanime/build.gradle
@@ -7,7 +7,7 @@ ext {
     extName = 'Gogoanime'
     pkgNameSuffix = 'en.gogoanime'
     extClass = '.GogoAnime'
-    extVersionCode = 77
+    extVersionCode = 78
     libVersion = '13'
 }
 

--- a/src/en/gogoanime/src/eu/kanade/tachiyomi/animeextension/en/gogoanime/GogoAnime.kt
+++ b/src/en/gogoanime/src/eu/kanade/tachiyomi/animeextension/en/gogoanime/GogoAnime.kt
@@ -35,7 +35,10 @@ class GogoAnime : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override val name = "Gogoanime"
 
-    override val baseUrl by lazy { preferences.getString(PREF_DOMAIN_KEY, PREF_DOMAIN_DEFAULT)!! }
+    override val baseUrl by lazy {
+        preferences.getString(PREF_DOMAIN_KEY, PREF_DOMAIN_DEFAULT).orEmpty()
+            .trim().ifBlank { PREF_DOMAIN_DEFAULT }
+    }
 
     override val lang = "en"
 
@@ -281,7 +284,7 @@ class GogoAnime : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
             setOnPreferenceChangeListener { _, newValue ->
                 runCatching {
-                    val value = (newValue as String).trim().ifEmpty { PREF_DOMAIN_DEFAULT }
+                    val value = (newValue as String).trim().ifBlank { PREF_DOMAIN_DEFAULT }
                     Toast.makeText(screen.context, "Restart Aniyomi to apply new setting.", Toast.LENGTH_LONG).show()
                     preferences.edit().putString(key, value).commit()
                 }.getOrDefault(false)


### PR DESCRIPTION
Note: For now, this PR **ISN'T** related to #2554.
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Have not changed source names
- [x] Have tested the modifications by compiling and running the extension through Android Studio
