### PR TITLE
fix(en/aniwave): add remaining official domains

### DIFF
--- a/src/en/aniwave/build.gradle
+++ b/src/en/aniwave/build.gradle
@@ -8,7 +8,7 @@ ext {
     extName = 'Aniwave'
     pkgNameSuffix = 'en.nineanime'
     extClass = '.Aniwave'
-    extVersionCode = 59
+    extVersionCode = 60
     libVersion = '13'
 }
 

--- a/src/en/aniwave/src/eu/kanade/tachiyomi/animeextension/en/nineanime/Aniwave.kt
+++ b/src/en/aniwave/src/eu/kanade/tachiyomi/animeextension/en/nineanime/Aniwave.kt
@@ -380,8 +380,8 @@ class Aniwave : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
         ListPreference(screen.context).apply {
             key = PREF_DOMAIN_KEY
             title = "Preferred domain"
-            entries = arrayOf("aniwave.to", "aniwave.bz", "aniwave.ws")
-            entryValues = arrayOf("https://aniwave.to", "https://aniwave.bz", "https://aniwave.ws")
+            entries = arrayOf("aniwave.to", "aniwave.bz", "aniwave.ws", "aniwave.vc")
+            entryValues = arrayOf("https://aniwave.to", "https://aniwave.bz", "https://aniwave.ws", "https://aniwave.vc")
             setDefaultValue(PREF_DOMAIN_DEFAULT)
             summary = "%s"
 


### PR DESCRIPTION
Closes #2590 
Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [X] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [X] Added the `containsNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [X] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio

