### PR TITLE
[skip ci] chore: Address deprecation warnings from gradle 8.5+

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -25,7 +25,7 @@ android {
         versionCode extVersionCode
         versionName project.ext.properties.getOrDefault("libVersion", "13") + ".$extVersionCode"
         base {
-            archivesBaseName = "aniyomi-$pkgNameSuffix-v$versionName"
+            archivesName = "aniyomi-$pkgNameSuffix-v$versionName"
         }
         def readmes = project.projectDir.listFiles({ File file ->
             file.name.equals("README.md") ||

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,7 +26,7 @@ File(rootDir, "lib").eachDir {
 // Fix deprecation warnings with Gradle 8.5+.
 // See https://docs.gradle.org/8.5/userguide/upgrading_version_8.html#deprecated_missing_project_directory
 listOf(
-    ":extensions" to rootDir,
+    ":extensions" to "$rootDir/gradle", // Temporary workaround.
     ":extensions:individual" to "$rootDir/src",
     ":extensions:multisrc" to "$rootDir/generated-src",
 ).forEach { (name, path) ->

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,6 +23,20 @@ File(rootDir, "lib").eachDir {
     project(":lib-$libName").projectDir = File("lib/$libName")
 }
 
+// Fix deprecation warnings with Gradle 8.5+.
+// See https://docs.gradle.org/8.5/userguide/upgrading_version_8.html#deprecated_missing_project_directory
+listOf(
+    ":extensions" to rootDir,
+    ":extensions:individual" to "$rootDir/src",
+    ":extensions:multisrc" to "$rootDir/generated-src",
+).forEach { (name, path) ->
+    val projectDir = file(path)
+    if (projectDir.exists()) {
+        include(name)
+        project(name).projectDir = projectDir
+    }
+}
+
 if (System.getenv("CI") == null || System.getenv("CI_MODULE_GEN") == "true") {
     // Local development (full project build)
 


### PR DESCRIPTION
Note: it'll still show a single warning, that happens due to the current Android Gradle Plugin version (8.0.2):
`The BuildIdentifier.getName() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/8.5/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation`

Upgrading the AGP to 8.2.0 addresses this, but this requires a bump of the gradle version (8.1.1 -> 8.2), so I'll leave it in the current state to prevent breaking dev environments(Outdated IDEs moment).