### PR TITLE
fix(ar/akwam/faselhd/egydead/tuktukcinema): Mass fix for some arabic extensions

### DIFF
--- a/src/ar/akwam/build.gradle
+++ b/src/ar/akwam/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'أكوام'
     pkgNameSuffix = 'ar.akwam'
     extClass = '.Akwam'
-    extVersionCode = 8
+    extVersionCode = 9
     libVersion = '13'
 }
 

--- a/src/ar/akwam/src/eu/kanade/tachiyomi/animeextension/ar/akwam/Akwam.kt
+++ b/src/ar/akwam/src/eu/kanade/tachiyomi/animeextension/ar/akwam/Akwam.kt
@@ -28,7 +28,7 @@ class Akwam : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override val name = "أكوام"
 
-    override val baseUrl = "https://akwam.im"
+    override val baseUrl = "https://akw-cdn1.link"
 
     override val lang = "ar"
 
@@ -100,7 +100,7 @@ class Akwam : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override fun videoListParse(response: Response): List<Video> {
         val document = response.asJsoup()
-        val iframe = "https://akwam.im/watch" + document.select("a.link-show").attr("href").substringAfter("watch") + "/" + document.ownerDocument()!!.select("input#page_id").attr("value")
+        val iframe = "https://akw-cdn1.link/watch" + document.select("a.link-show").attr("href").substringAfter("watch") + "/" + document.ownerDocument()!!.select("input#page_id").attr("value")
         val referer = response.request.url.toString()
         val refererHeaders = Headers.headersOf("referer", referer)
         val iframeResponse = client.newCall(GET(iframe, refererHeaders))

--- a/src/ar/egydead/build.gradle
+++ b/src/ar/egydead/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Egy Dead'
     pkgNameSuffix = 'ar.egydead'
     extClass = '.EgyDead'
-    extVersionCode = 6
+    extVersionCode = 7
     libVersion = '13'
 }
 

--- a/src/ar/egydead/src/eu/kanade/tachiyomi/animeextension/ar/egydead/EgyDead.kt
+++ b/src/ar/egydead/src/eu/kanade/tachiyomi/animeextension/ar/egydead/EgyDead.kt
@@ -319,7 +319,7 @@ class EgyDead : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     private fun getPrefHostUrl(preferences: SharedPreferences): String = preferences.getString(
         "default_domain",
-        "https://w9.egydead.live/",
+        "https://egydead.space/",
     )!!.trim()
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
@@ -365,7 +365,7 @@ class EgyDead : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
     // like|kharabnahk
     companion object {
         private val DOOD_REGEX = Regex("(do*d(?:stream)?\\.(?:com?|watch|to|s[ho]|cx|la|w[sf]|pm|re|yt|stream))/[de]/([0-9a-zA-Z]+)")
-        private val STREAMWISH_REGEX = Regex("ajmidyad|alhayabambi|atabknh[ks]|file")
+        private val STREAMWISH_REGEX = Regex("ajmidyad|alhayabambi|atabknh[ks]|file|egtpgrvh")
         private val SOURCE_URL_REGEX = Regex("sources:\\s*\\[\\{\\s*\\t*file:\\s*[\"']([^\"']+)")
         private val QUALITIES_REGEX = Regex("(.*)_,(.*),\\.urlset/master(.*)")
     }

--- a/src/ar/egydead/src/eu/kanade/tachiyomi/animeextension/ar/egydead/EgyDead.kt
+++ b/src/ar/egydead/src/eu/kanade/tachiyomi/animeextension/ar/egydead/EgyDead.kt
@@ -6,6 +6,7 @@ import android.widget.Toast
 import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
+import eu.kanade.tachiyomi.animeextension.BuildConfig
 import dev.datlag.jsunpacker.JsUnpacker
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilter
@@ -318,7 +319,7 @@ class EgyDead : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
     // ================================== preferences ==================================
 
     private fun getPrefHostUrl(preferences: SharedPreferences): String = preferences.getString(
-        "default_domain",
+        "default_domain_v${BuildConfig.VERSION_CODE}",
         "https://egydead.space/",
     )!!.trim()
 

--- a/src/ar/faselhd/build.gradle
+++ b/src/ar/faselhd/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'فاصل اعلاني'
     pkgNameSuffix = 'ar.faselhd'
     extClass = '.FASELHD'
-    extVersionCode = 13
+    extVersionCode = 14
     libVersion = '13'
 }
 

--- a/src/ar/faselhd/src/eu/kanade/tachiyomi/animeextension/ar/faselhd/FASELHD.kt
+++ b/src/ar/faselhd/src/eu/kanade/tachiyomi/animeextension/ar/faselhd/FASELHD.kt
@@ -28,7 +28,7 @@ class FASELHD : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override val name = "فاصل اعلاني"
 
-    override val baseUrl = "https://www.faselhd.vip"
+    override val baseUrl = "https://www.faselhd.pro"
 
     override val lang = "ar"
 

--- a/src/ar/tuktukcinema/build.gradle
+++ b/src/ar/tuktukcinema/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation(project(':lib-streamtape-extractor'))
     implementation(project(':lib-vidbom-extractor'))
     implementation "dev.datlag.jsunpacker:jsunpacker:1.0.1"
+    implementation(project(':lib-playlist-utils'))
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ar/tuktukcinema/build.gradle
+++ b/src/ar/tuktukcinema/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'توك توك سينما'
     pkgNameSuffix = 'ar.tuktukcinema'
     extClass = '.Tuktukcinema'
-    extVersionCode = 10
+    extVersionCode = 11
     libVersion = '13'
 }
 

--- a/src/ar/tuktukcinema/src/eu/kanade/tachiyomi/animeextension/ar/tuktukcinema/Tuktukcinema.kt
+++ b/src/ar/tuktukcinema/src/eu/kanade/tachiyomi/animeextension/ar/tuktukcinema/Tuktukcinema.kt
@@ -167,7 +167,7 @@ class Tuktukcinema : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
                 val request = client.newCall(GET(url, headers)).execute().asJsoup()
                 val data = request.selectFirst("script:containsData(m3u8)")!!.data()
                 val masterUrl = data.substringAfter("sources: [{").substringAfter("file:\"").substringBefore("\"}")
-                PlaylistUtils(client, headers).extractFromHls(masterUrl)
+                playlistUtils.extractFromHls(masterUrl)
             }
             url.contains("ok") -> {
                 OkruExtractor(client).videosFromUrl(url)


### PR DESCRIPTION
add new extractor in tuktukcinema
fix baseurl in faselhd , egydead and akwam

closes #2195
closes #992

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `containsNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
