### PR TITLE
Fix (src/ar) fix regex for streamwish links

### DIFF
--- a/src/ar/egydead/build.gradle
+++ b/src/ar/egydead/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Egy Dead'
     pkgNameSuffix = 'ar.egydead'
     extClass = '.EgyDead'
-    extVersionCode = 8
+    extVersionCode = 9
     libVersion = '13'
 }
 

--- a/src/ar/egydead/src/eu/kanade/tachiyomi/animeextension/ar/egydead/EgyDead.kt
+++ b/src/ar/egydead/src/eu/kanade/tachiyomi/animeextension/ar/egydead/EgyDead.kt
@@ -351,6 +351,6 @@ class EgyDead : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
     // like|kharabnahk
     companion object {
         private val DOOD_REGEX = Regex("(do*d(?:stream)?\\.(?:com?|watch|to|s[ho]|cx|la|w[sf]|pm|re|yt|stream))/[de]/([0-9a-zA-Z]+)|ds2play")
-        private val STREAMWISH_REGEX = Regex("ajmidyad|alhayabambi|atabknh[ks]|file|egtpgrvh")
+        private val STREAMWISH_REGEX = Regex("ajmidyad|alhayabambi|atabknh[ks]|file|eg.*\.[A-Za-z]+")
     }
 }

--- a/src/ar/tuktukcinema/build.gradle
+++ b/src/ar/tuktukcinema/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'توك توك سينما'
     pkgNameSuffix = 'ar.tuktukcinema'
     extClass = '.Tuktukcinema'
-    extVersionCode = 12
+    extVersionCode = 13
     libVersion = '13'
 }
 

--- a/src/ar/tuktukcinema/src/eu/kanade/tachiyomi/animeextension/ar/tuktukcinema/Tuktukcinema.kt
+++ b/src/ar/tuktukcinema/src/eu/kanade/tachiyomi/animeextension/ar/tuktukcinema/Tuktukcinema.kt
@@ -352,6 +352,6 @@ class Tuktukcinema : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
     companion object {
         private val VIDBOM_REGEX = Regex("(?:v[aie]d[bp][aoe]?m|myvii?d|govad|segavid|v[aei]{1,2}dshar[er]?)\\.(?:com|net|org|xyz)(?::\\d+)?/(?:embed[/-])?([A-Za-z0-9]+).html")
         private val DOOD_REGEX = Regex("(do*d(?:stream)?\\.(?:com?|watch|to|s[ho]|cx|la|w[sf]|pm|re|yt|stream))/[de]/([0-9a-zA-Z]+)|ds2play")
-        private val STREAMWISH_REGEX = Regex("ajmidyad|alhayabambi|atabknh[ks]|file|egtpgrvh")
+        private val STREAMWISH_REGEX = Regex("ajmidyad|alhayabambi|atabknh[ks]|file|eg.*\.[A-Za-z]+")
     }
 }


### PR DESCRIPTION
fix regex for streamwish links in egydead and tuktukcinema

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `containsNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
