### PR TITLE
built in key finder for multisrc/aniwatch/kaido

### DIFF
--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/zorotheme/ZoroThemeGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/zorotheme/ZoroThemeGenerator.kt
@@ -11,8 +11,8 @@ class ZoroThemeGenerator : ThemeSourceGenerator {
     override val baseVersionCode = 1
 
     override val sources = listOf(
-        SingleLang("AniWatch", "https://aniwatch.to", "en", isNsfw = false, pkgName = "zoro", overrideVersionCode = 35),
-        SingleLang("Kaido", "https://kaido.to", "en", isNsfw = false, overrideVersionCode = 2),
+        SingleLang("AniWatch", "https://aniwatch.to", "en", isNsfw = false, pkgName = "zoro", overrideVersionCode = 36),
+        SingleLang("Kaido", "https://kaido.to", "en", isNsfw = false, overrideVersionCode = 3),
     )
 
     companion object {

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/zorotheme/ZoroThemeGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/zorotheme/ZoroThemeGenerator.kt
@@ -11,8 +11,8 @@ class ZoroThemeGenerator : ThemeSourceGenerator {
     override val baseVersionCode = 1
 
     override val sources = listOf(
-        SingleLang("AniWatch", "https://aniwatch.to", "en", isNsfw = false, pkgName = "zoro", overrideVersionCode = 36),
-        SingleLang("Kaido", "https://kaido.to", "en", isNsfw = false, overrideVersionCode = 3),
+        SingleLang("AniWatch", "https://aniwatch.to", "en", isNsfw = false, pkgName = "zoro", overrideVersionCode = 35),
+        SingleLang("Kaido", "https://kaido.to", "en", isNsfw = false, overrideVersionCode = 2),
     )
 
     companion object {


### PR DESCRIPTION
Fixes https://github.com/aniyomiorg/aniyomi-extensions/issues/2568
Alternate to: https://github.com/aniyomiorg/aniyomi-extensions/pull/2711

Tested on both Kaido and AniWatch

 Uses regex to find the keys in the obfuscated js file.

 This is slightly slower than pulling the key straight from GitHub, but not nearly as bad as de-obfuscating the JavaScript  (not noticeable in daily use).
 Obvious benefit of having always up to date keys.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `containsNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio