### PR TITLE
Fix yomiroll crash on Local Token toggle

### DIFF
--- a/src/all/kamyroll/build.gradle
+++ b/src/all/kamyroll/build.gradle
@@ -8,7 +8,7 @@ ext {
     extName = 'Yomiroll'
     pkgNameSuffix = 'all.kamyroll'
     extClass = '.Yomiroll'
-    extVersionCode = 25
+    extVersionCode = 26
     libVersion = '13'
 }
 

--- a/src/all/kamyroll/src/eu/kanade/tachiyomi/animeextension/all/kamyroll/Yomiroll.kt
+++ b/src/all/kamyroll/src/eu/kanade/tachiyomi/animeextension/all/kamyroll/Yomiroll.kt
@@ -513,11 +513,9 @@ class Yomiroll : ConfigurableAnimeSource, AnimeHttpSource() {
                     setOnPreferenceChangeListener { _, newValue ->
                         val new = newValue as Boolean
                         preferences.edit().putBoolean(key, new).commit().also {
-                            Thread {
-                                summary = runBlocking {
-                                    withContext(Dispatchers.IO) { getTokenDetail(true) }
-                                }
-                            }.start()
+                            summary = runBlocking {
+                                withContext(Dispatchers.IO) { getTokenDetail(true) }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Fixed by removing a thread
Pros :
- Doesn't crash anymore
- Freezes whole UI until switch is updated
- 2 lines fix
Cons :
- Absolutely none

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [X] Have not changed source names
- [X] Have tested the modifications by compiling and running the extension through Android Studio