### PR TITLE
fix(all/yomiroll): Fetch anime status from AniList.co

### DIFF
--- a/src/all/kamyroll/build.gradle
+++ b/src/all/kamyroll/build.gradle
@@ -8,7 +8,7 @@ ext {
     extName = 'Yomiroll'
     pkgNameSuffix = 'all.kamyroll'
     extClass = '.Yomiroll'
-    extVersionCode = 26
+    extVersionCode = 27
     libVersion = '13'
 }
 

--- a/src/all/kamyroll/src/eu/kanade/tachiyomi/animeextension/all/kamyroll/DataModel.kt
+++ b/src/all/kamyroll/src/eu/kanade/tachiyomi/animeextension/all/kamyroll/DataModel.kt
@@ -58,7 +58,6 @@ data class Anime(
     @SerialName("keywords")
     val genres: ArrayList<String>? = null,
     val series_metadata: Metadata? = null,
-    val is_simulcast: Boolean? = null,
     @SerialName("movie_listing_metadata")
     val movie_metadata: MovieMeta? = null,
     val content_provider: String? = null,
@@ -172,6 +171,22 @@ data class Subtitle(
     val locale: String,
     val url: String,
 )
+
+@Serializable
+data class AnilistResult(
+    val data: AniData,
+) {
+    @Serializable
+    data class AniData(
+        @SerialName("Media")
+        val media: Media? = null,
+    )
+
+    @Serializable
+    data class Media(
+        val status: String,
+    )
+}
 
 fun <T> List<T>.thirdLast(): T? {
     if (size < 3) return null

--- a/src/all/kamyroll/src/eu/kanade/tachiyomi/animeextension/all/kamyroll/DataModel.kt
+++ b/src/all/kamyroll/src/eu/kanade/tachiyomi/animeextension/all/kamyroll/DataModel.kt
@@ -58,6 +58,7 @@ data class Anime(
     @SerialName("keywords")
     val genres: ArrayList<String>? = null,
     val series_metadata: Metadata? = null,
+    val is_simulcast: Boolean? = null,
     @SerialName("movie_listing_metadata")
     val movie_metadata: MovieMeta? = null,
     val content_provider: String? = null,

--- a/src/all/kamyroll/src/eu/kanade/tachiyomi/animeextension/all/kamyroll/Yomiroll.kt
+++ b/src/all/kamyroll/src/eu/kanade/tachiyomi/animeextension/all/kamyroll/Yomiroll.kt
@@ -71,9 +71,7 @@ class Yomiroll : ConfigurableAnimeSource, AnimeHttpSource() {
         super.client.newBuilder().addInterceptor(tokenInterceptor).build()
     }
 
-    private val noTokenClient by lazy {
-        super.client.newBuilder().build()
-    }
+    private val noTokenClient = super.client
 
     // ============================== Popular ===============================
 


### PR DESCRIPTION
Closes #2326 

Uses API provided by Anilist.co (https://anilist.github.io/ApiV2-GraphQL-Docs/) to fetch series status as CR won't track for itself. Inspired by https://github.com/aniyomiorg/aniyomi-extensions/pull/2055/files

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `containsNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
