### PR TITLE
fix(pt/goanimes): Fix linkfun bypasser

### DIFF
--- a/multisrc/overrides/dooplay/goanimes/src/extractors/LinkfunBypasser.kt
+++ b/multisrc/overrides/dooplay/goanimes/src/extractors/LinkfunBypasser.kt
@@ -11,10 +11,14 @@ import okhttp3.Response
 class LinkfunBypasser(private val client: OkHttpClient) {
     fun getIframeUrl(response: Response): String {
         return response.use { page ->
-            val document = page.asJsoup(decodeAtob(page.body.string()))
+            val docString = page.body.string()
+            val document = if (docString.startsWith("<script")) {
+                page.asJsoup(decodeAtob(docString))
+            } else { page.asJsoup(docString) }
+
             val newHeaders = Headers.headersOf("Referer", document.location())
 
-            val iframe = document.selectFirst("iframe")
+            val iframe = document.selectFirst("iframe[src]")
 
             if (iframe != null) {
                 iframe.attr("src")

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/dooplay/DooPlayGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/dooplay/DooPlayGenerator.kt
@@ -19,7 +19,7 @@ class DooPlayGenerator : ThemeSourceGenerator {
         SingleLang("Animes House", "https://animeshouse.net", "pt-BR", isNsfw = false, overrideVersionCode = 8),
         SingleLang("Cinemathek", "https://cinemathek.net", "de", isNsfw = true, overrideVersionCode = 17),
         SingleLang("DonghuaX", "https://donghuax.com", "pt-BR", isNsfw = false, overrideVersionCode = 1),
-        SingleLang("GoAnimes", "https://goanimes.net", "pt-BR", isNsfw = true, overrideVersionCode = 6),
+        SingleLang("GoAnimes", "https://goanimes.net", "pt-BR", isNsfw = true, overrideVersionCode = 7),
         SingleLang("JetAnime", "https://ssl.jetanimes.com", "fr", isNsfw = false, overrideVersionCode = 2),
         SingleLang("Kinoking", "https://kinoking.cc", "de", isNsfw = false, overrideVersionCode = 19),
         SingleLang("Multimovies", "https://multimovies.live", "en", isNsfw = false, overrideVersionCode = 13),


### PR DESCRIPTION
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `containsNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
