### PR TITLE
fix(all/yomiroll): Fix multi season anime status incorrectly retrieved

### DIFF
--- a/src/all/kamyroll/build.gradle
+++ b/src/all/kamyroll/build.gradle
@@ -8,7 +8,7 @@ ext {
     extName = 'Yomiroll'
     pkgNameSuffix = 'all.kamyroll'
     extClass = '.Yomiroll'
-    extVersionCode = 27
+    extVersionCode = 28
     libVersion = '13'
 }
 

--- a/src/all/kamyroll/src/eu/kanade/tachiyomi/animeextension/all/kamyroll/Yomiroll.kt
+++ b/src/all/kamyroll/src/eu/kanade/tachiyomi/animeextension/all/kamyroll/Yomiroll.kt
@@ -137,7 +137,7 @@ class Yomiroll : ConfigurableAnimeSource, AnimeHttpSource() {
     private fun fetchStatusByTitle(title: String): Int {
         val query = """
             query {
-            	Media(search: "$title", isAdult: false,	type: ANIME) {
+            	Media(search: "$title", isAdult: false, sort: UPDATED_AT, type: ANIME) {
                 id
                 idMal
                 title {


### PR DESCRIPTION
Fixes status for multi season anime (eg. Classroom of Elite) that were considered completed instead of ongoing etc.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `containsNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
