### PR TITLE
fix(all/yamiroll): Better sort request

### DIFF
--- a/src/all/kamyroll/build.gradle
+++ b/src/all/kamyroll/build.gradle
@@ -8,7 +8,7 @@ ext {
     extName = 'Yomiroll'
     pkgNameSuffix = 'all.kamyroll'
     extClass = '.Yomiroll'
-    extVersionCode = 28
+    extVersionCode = 29
     libVersion = '13'
 }
 

--- a/src/all/kamyroll/src/eu/kanade/tachiyomi/animeextension/all/kamyroll/Yomiroll.kt
+++ b/src/all/kamyroll/src/eu/kanade/tachiyomi/animeextension/all/kamyroll/Yomiroll.kt
@@ -137,7 +137,7 @@ class Yomiroll : ConfigurableAnimeSource, AnimeHttpSource() {
     private fun fetchStatusByTitle(title: String): Int {
         val query = """
             query {
-            	Media(search: "$title", isAdult: false, sort: UPDATED_AT, type: ANIME) {
+            	Media(search: "$title", isAdult: false, sort: START_DATE_DESC, type: ANIME) {
                 id
                 idMal
                 title {


### PR DESCRIPTION
Known issue (unrelated to this patch): for some reason, AniList would suggest anime that are totally unrelated to the query (eg. https://anilist.co/search/anime?search=SSSS.GRIDMAN). I may fix this if I use `episode_count` for `episodes` but more testing is required.

I'll leave this PR as draft as I'm RFC.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `containsNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
