### PR TITLE
fix(es/Hackstore): Fix orden ep and not found description

### DIFF
--- a/src/es/hackstore/build.gradle
+++ b/src/es/hackstore/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Hackstore'
     extClass = '.Hackstore'
-    extVersionCode = 1
+    extVersionCode = 2
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/hackstore/src/eu/kanade/tachiyomi/animeextension/es/hackstore/Hackstore.kt
+++ b/src/es/hackstore/src/eu/kanade/tachiyomi/animeextension/es/hackstore/Hackstore.kt
@@ -117,7 +117,7 @@ class Hackstore : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     // =========================== Anime Details ============================
     override fun animeDetailsParse(document: Document): SAnime {
-        val ismovie = getFilterList().find { it is GenreFilter }?.let { it as GenreFilter }?.toUriPart() == "peliculas"
+        val ismovie = document.selectFirst("#main-content > div > div.content-area.twelve.columns > div.watch-content > center > div > p:nth-child(1)") != null
         if (ismovie) {
             val anime = SAnime.create()
             anime.description = document.selectFirst("#main-content > div > div.content-area.twelve.columns > div.watch-content > center > div > p:nth-child(1)")!!.text().removeSurrounding("\"")
@@ -175,6 +175,7 @@ class Hackstore : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
                 episode.name = "T$seasonNumber - E$episodeNumber"
                 episode.episode_number = episodeNumber.toFloat()
+                episodeList.add(0, episode)
                 episode.setUrlWithoutDomain(episodeLink)
 
                 episodeList.add(episode)


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
