### PR TITLE
fix(all/yomiroll): Make pref subtitle show up first in case app can't determine locale

### DIFF
--- a/src/all/kamyroll/build.gradle
+++ b/src/all/kamyroll/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Yomiroll'
     extClass = '.Yomiroll'
-    extVersionCode = 29
+    extVersionCode = 30
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/kamyroll/src/eu/kanade/tachiyomi/animeextension/all/kamyroll/Yomiroll.kt
+++ b/src/all/kamyroll/src/eu/kanade/tachiyomi/animeextension/all/kamyroll/Yomiroll.kt
@@ -354,7 +354,6 @@ class Yomiroll : ConfigurableAnimeSource, AnimeHttpSource() {
         Pair("en-IN", "English (India)"),
         Pair("es-419", "Spanish (América Latina)"),
         Pair("es-ES", "Spanish (España)"),
-        Pair("es-LA", "Spanish (América Latina)"),
         Pair("fr-FR", "French"),
         Pair("ja-JP", "Japanese"),
         Pair("hi-IN", "Hindi"),
@@ -414,7 +413,7 @@ class Yomiroll : ConfigurableAnimeSource, AnimeHttpSource() {
                 }
             } ?: SAnime.UNKNOWN
             author = content_provider
-            description = anime?.description ?: StringBuilder().apply {
+            description = StringBuilder().apply {
                 appendLine(this@toSAnime.description)
                 appendLine()
 

--- a/src/all/kamyroll/src/eu/kanade/tachiyomi/animeextension/all/kamyroll/Yomiroll.kt
+++ b/src/all/kamyroll/src/eu/kanade/tachiyomi/animeextension/all/kamyroll/Yomiroll.kt
@@ -188,7 +188,8 @@ class Yomiroll : ConfigurableAnimeSource, AnimeHttpSource() {
         return info.data.first().toSAnimeOrNull(anime) ?: anime
     }
 
-    override fun animeDetailsParse(response: Response): SAnime = throw UnsupportedOperationException()
+    override fun animeDetailsParse(response: Response): SAnime =
+        throw UnsupportedOperationException()
 
     // ============================== Episodes ==============================
 
@@ -287,10 +288,8 @@ class Yomiroll : ConfigurableAnimeSource, AnimeHttpSource() {
                 val sub = json.decodeFromString<Subtitle>(value.jsonObject.toString())
                 Track(sub.url, sub.locale.getLocale())
             }?.sortedWith(
-                compareBy(
-                    { it.lang },
-                    { it.lang.contains(subLocale) },
-                ),
+                compareByDescending<Track> { it.lang.contains(subLocale) }
+                    .thenBy { it.lang },
             )
         }.getOrNull() ?: emptyList()
 


### PR DESCRIPTION
And remove duplicate locale as CR is using the other also sub preference index will be shuffled, users gotta re-select preference

Closes #2846

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `containsNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
