### PR TITLE
fix(pt/animefire): Fix http 401 + update domain (#2861)

### DIFF
--- a/src/pt/animefire/AndroidManifest.xml
+++ b/src/pt/animefire/AndroidManifest.xml
@@ -14,7 +14,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data
-                    android:host="animefire.net"
+                    android:host="animefire.plus"
                     android:pathPattern="/animes/..*"
                     android:scheme="https" />
             </intent-filter>

--- a/src/pt/animefire/build.gradle
+++ b/src/pt/animefire/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Anime Fire'
     extClass = '.AnimeFire'
-    extVersionCode = 5
+    extVersionCode = 6
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/animefire/src/eu/kanade/tachiyomi/animeextension/pt/animefire/AnimeFire.kt
+++ b/src/pt/animefire/src/eu/kanade/tachiyomi/animeextension/pt/animefire/AnimeFire.kt
@@ -28,7 +28,7 @@ class AnimeFire : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override val name = "Anime Fire"
 
-    override val baseUrl = "https://animefire.net"
+    override val baseUrl = "https://animefire.plus"
 
     override val lang = "pt-BR"
 
@@ -146,7 +146,7 @@ class AnimeFire : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
         val document = response.asJsoup()
         val videoElement = document.selectFirst("video#my-video")
         return if (videoElement != null) {
-            AnimeFireExtractor(client, json).videoListFromElement(videoElement)
+            AnimeFireExtractor(client, json).videoListFromElement(videoElement, headers)
         } else {
             IframeExtractor(client).videoListFromDocument(document, headers)
         }

--- a/src/pt/animefire/src/eu/kanade/tachiyomi/animeextension/pt/animefire/extractors/AnimeFireExtractor.kt
+++ b/src/pt/animefire/src/eu/kanade/tachiyomi/animeextension/pt/animefire/extractors/AnimeFireExtractor.kt
@@ -4,19 +4,20 @@ import eu.kanade.tachiyomi.animeextension.pt.animefire.dto.AFResponseDto
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
 import kotlinx.serialization.json.Json
+import okhttp3.Headers
 import okhttp3.OkHttpClient
 import org.jsoup.nodes.Element
 
 class AnimeFireExtractor(private val client: OkHttpClient, private val json: Json) {
 
-    fun videoListFromElement(videoElement: Element): List<Video> {
+    fun videoListFromElement(videoElement: Element, headers: Headers): List<Video> {
         val jsonUrl = videoElement.attr("data-video-src")
         val response = client.newCall(GET(jsonUrl)).execute()
             .body.string()
         val responseDto = json.decodeFromString<AFResponseDto>(response)
         return responseDto.videos.map {
             val url = it.url.replace("\\", "")
-            Video(url, it.quality, url)
+            Video(url, it.quality, url, headers = headers)
         }
     }
 }


### PR DESCRIPTION
Closes #2861 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `containsNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
