### PR TITLE
fix(es/AnimeFLV): change servers info

### DIFF
--- a/lib/streamtape-extractor/src/main/java/eu/kanade/tachiyomi/lib/streamtapeextractor/StreamTapeExtractor.kt
+++ b/lib/streamtape-extractor/src/main/java/eu/kanade/tachiyomi/lib/streamtapeextractor/StreamTapeExtractor.kt
@@ -7,7 +7,7 @@ import eu.kanade.tachiyomi.util.asJsoup
 import okhttp3.OkHttpClient
 
 class StreamTapeExtractor(private val client: OkHttpClient) {
-    fun videoFromUrl(url: String, quality: String = "StreamTape", subtitleList: List<Track> = emptyList()): Video? {
+    fun videoFromUrl(url: String, quality: String = "Streamtape", subtitleList: List<Track> = emptyList()): Video? {
         val baseUrl = "https://streamtape.com/e/"
         val newUrl = if (!url.startsWith(baseUrl)) {
             // ["https", "", "<domain>", "<???>", "<id>", ...]
@@ -27,7 +27,7 @@ class StreamTapeExtractor(private val client: OkHttpClient) {
         return Video(videoUrl, quality, videoUrl, subtitleTracks = subtitleList)
     }
 
-    fun videosFromUrl(url: String, quality: String = "StreamTape", subtitleList: List<Track> = emptyList()): List<Video> {
+    fun videosFromUrl(url: String, quality: String = "Streamtape", subtitleList: List<Track> = emptyList()): List<Video> {
         return videoFromUrl(url, quality, subtitleList)?.let(::listOf).orEmpty()
     }
 }

--- a/src/es/animeflv/build.gradle
+++ b/src/es/animeflv/build.gradle
@@ -10,6 +10,5 @@ dependencies {
     implementation(project(':lib:yourupload-extractor'))
     implementation(project(':lib:streamtape-extractor'))
     implementation(project(':lib:okru-extractor'))
-    implementation(project(':lib:dood-extractor'))
     implementation(project(':lib:streamwish-extractor'))
 }

--- a/src/es/animeflv/build.gradle
+++ b/src/es/animeflv/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimeFLV'
     extClass = '.AnimeFlv'
-    extVersionCode = 52
+    extVersionCode = 53
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/animeflv/src/eu/kanade/tachiyomi/animeextension/es/animeflv/AnimeFlv.kt
+++ b/src/es/animeflv/src/eu/kanade/tachiyomi/animeextension/es/animeflv/AnimeFlv.kt
@@ -11,7 +11,6 @@ import eu.kanade.tachiyomi.animesource.model.SAnime
 import eu.kanade.tachiyomi.animesource.model.SEpisode
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.animesource.online.ParsedAnimeHttpSource
-import eu.kanade.tachiyomi.lib.doodextractor.DoodExtractor
 import eu.kanade.tachiyomi.lib.okruextractor.OkruExtractor
 import eu.kanade.tachiyomi.lib.streamtapeextractor.StreamTapeExtractor
 import eu.kanade.tachiyomi.lib.streamwishextractor.StreamWishExtractor
@@ -50,12 +49,12 @@ class AnimeFlv : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     companion object {
         private const val PREF_QUALITY_KEY = "preferred_quality"
-        private const val PREF_QUALITY_DEFAULT = "1080"
+        private const val PREF_QUALITY_DEFAULT = "480"
         private val QUALITY_LIST = arrayOf("1080", "720", "480", "360")
 
         private const val PREF_SERVER_KEY = "preferred_server"
-        private const val PREF_SERVER_DEFAULT = "YourUpload"
-        private val SERVER_LIST = arrayOf("MailRu", "Okru", "YourUpload", "DoodStream", "StreamTape")
+        private const val PREF_SERVER_DEFAULT = "StreamWish"
+        private val SERVER_LIST = arrayOf("StreamWish", "YourUpload", "Mail.ru", "OK.ru", "Streamtape")
     }
 
     override fun popularAnimeSelector(): String = "div.Container ul.ListAnimes li article"
@@ -123,7 +122,6 @@ class AnimeFlv : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
                                 val stapeUrl = json!!["url"]!!.jsonPrimitive!!.content
                                 StreamTapeExtractor(client).videoFromUrl(stapeUrl)?.let(::listOf)
                             }
-                            "Doodstream" -> DoodExtractor(client).videoFromUrl(url, "DoodStream", false)?.let(::listOf)
                             "Okru" -> OkruExtractor(client).videosFromUrl(url)
                             "YourUpload" -> YourUploadExtractor(client).videoFromUrl(url, headers = headers)
                             "SW" -> {

--- a/src/es/animeflv/src/eu/kanade/tachiyomi/animeextension/es/animeflv/AnimeFlv.kt
+++ b/src/es/animeflv/src/eu/kanade/tachiyomi/animeextension/es/animeflv/AnimeFlv.kt
@@ -54,7 +54,7 @@ class AnimeFlv : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
         private const val PREF_SERVER_KEY = "preferred_server"
         private const val PREF_SERVER_DEFAULT = "StreamWish"
-        private val SERVER_LIST = arrayOf("StreamWish", "YourUpload", "Mail.ru", "OK.ru", "Streamtape")
+        private val SERVER_LIST = arrayOf("StreamWish", "YourUpload", "Okru", "Streamtape")
     }
 
     override fun popularAnimeSelector(): String = "div.Container ul.ListAnimes li article"
@@ -128,7 +128,7 @@ class AnimeFlv : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
                                 val docHeaders = headers.newBuilder()
                                     .add("Referer", "$baseUrl/")
                                     .build()
-                                StreamWishExtractor(client, docHeaders).videosFromUrl(url, videoNameGen = { "StreamWish:$it" })
+                                StreamWishExtractor(client, docHeaders).videosFromUrl(url, videoNameGen = { "StreamWish: $it" })
                             }
                             else -> null
                         }


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `containsNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio

Changes:
- Removed DoodStream as it isn't available anymore as a server option
- Added StreamWish to the SERVER_LIST array (why it wasn't there?)
- Ordered as like on the website the SERVER_LIST array (optional)
- Changed PREF_QUALITY_DEFAULT to 480, as no server provides 1080p, and the only providing 480p and works well is StreamWish (Okru I think too)
- Changed PREF_SERVER_DEFAULT to StreamWish, as it's usually the best that works without that many ads, after MEGA
- Updated extension version to 53

---

- Removed maru server (doesn't even have a backend)
- Added a blank space to the SW extractor output

Non-related:
- Update Stape wording from StreamTape to Streamtape (lib)