### PR TITLE
Jellyfin: add custom labels + number of sources

### DIFF
--- a/src/all/jellyfin/build.gradle
+++ b/src/all/jellyfin/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Jellyfin'
     extClass = '.JellyfinFactory'
-    extVersionCode = 12
+    extVersionCode = 13
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/jellyfin/src/eu/kanade/tachiyomi/animeextension/all/jellyfin/JellyfinFactory.kt
+++ b/src/all/jellyfin/src/eu/kanade/tachiyomi/animeextension/all/jellyfin/JellyfinFactory.kt
@@ -1,11 +1,18 @@
 package eu.kanade.tachiyomi.animeextension.all.jellyfin
 
+import eu.kanade.tachiyomi.animesource.AnimeSource
 import eu.kanade.tachiyomi.animesource.AnimeSourceFactory
 
 class JellyfinFactory : AnimeSourceFactory {
-    override fun createSources() = listOf(
-        Jellyfin(""),
-        Jellyfin(" (2)"),
-        Jellyfin(" (3)"),
-    )
+    override fun createSources(): List<AnimeSource> {
+        val firstJelly = Jellyfin("1")
+        val extraCount = firstJelly.preferences.getString(Jellyfin.EXTRA_SOURCES_COUNT_KEY, Jellyfin.EXTRA_SOURCES_COUNT_DEFAULT)!!.toInt()
+
+        return buildList(extraCount) {
+            add(firstJelly)
+            for (i in 2..extraCount) {
+                add(Jellyfin("$i"))
+            }
+        }
+    }
 }


### PR DESCRIPTION
* Adds preference to customize name
* Adds preference for number of sources
* Makes jellyfin an unmetered source

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `containsNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
