### PR TITLE
Torrentio: Fix Videolist empty for Movies.

### DIFF
--- a/src/all/torrentioanime/build.gradle
+++ b/src/all/torrentioanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Torrentio Anime (Torrent / Debrid)'
     extClass = '.Torrentio'
-    extVersionCode = 2
+    extVersionCode = 3
     containsNsfw = false
 }
 

--- a/src/all/torrentioanime/src/eu/kanade/tachiyomi/animeextension/all/torrentioanime/Torrentio.kt
+++ b/src/all/torrentioanime/src/eu/kanade/tachiyomi/animeextension/all/torrentioanime/Torrentio.kt
@@ -379,11 +379,10 @@ class Torrentio : ConfigurableAnimeSource, AnimeHttpSource() {
 
             "movie" -> {
                 // Handle movie response
-                val movieId = episodeList.meta.kitsuId?.substringAfterLast(":")?.toIntOrNull() ?: 0
                 listOf(
                     SEpisode.create().apply {
                         episode_number = 1.0F
-                        url = "/stream/movie/$movieId.json"
+                        url = "/stream/movie/${episodeList.meta.kitsuId}.json"
                         name = "Movie"
                     },
                 ).reversed()


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `containsNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
