### PR TITLE
fix(tr/animeler): Fix anime pages + fix extractor

### DIFF
--- a/src/tr/animeler/build.gradle
+++ b/src/tr/animeler/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Animeler'
     extClass = '.Animeler'
-    extVersionCode = 9
+    extVersionCode = 10
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/tr/animeler/src/eu/kanade/tachiyomi/animeextension/tr/animeler/Animeler.kt
+++ b/src/tr/animeler/src/eu/kanade/tachiyomi/animeextension/tr/animeler/Animeler.kt
@@ -44,6 +44,7 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
+import org.jsoup.Jsoup
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import uy.kohesive.injekt.injectLazy
@@ -71,13 +72,17 @@ class Animeler : AnimeHttpSource(), ConfigurableAnimeSource {
 
     override fun popularAnimeParse(response: Response): AnimesPage {
         val results = response.parseAs<SearchResponseDto>()
-        val animes = results.data.map {
+        val doc = Jsoup.parseBodyFragment(results.data)
+        val animes = doc.select("div.w-full:has(div.kira-anime)").map {
             SAnime.create().apply {
-                setUrlWithoutDomain(it.url)
-                thumbnail_url = it.thumbnail
-                title = it.title
+                thumbnail_url = it.selectFirst("img")?.attr("src")
+                with(it.selectFirst("h3 > a")!!) {
+                    title = text()
+                    setUrlWithoutDomain(attr("href"))
+                }
             }
         }
+
         val page = response.request.url.queryParameter("page")?.toIntOrNull() ?: 1
         val hasNextPage = page < results.pages
         return AnimesPage(animes, hasNextPage)

--- a/src/tr/animeler/src/eu/kanade/tachiyomi/animeextension/tr/animeler/Animeler.kt
+++ b/src/tr/animeler/src/eu/kanade/tachiyomi/animeextension/tr/animeler/Animeler.kt
@@ -230,7 +230,7 @@ class Animeler : AnimeHttpSource(), ConfigurableAnimeSource {
     override fun videoListParse(response: Response): List<Video> {
         val doc = response.asJsoup()
         val iframeUrl = doc.selectFirst("div.episode-player-box > iframe")
-            ?.attr("src")
+            ?.run { attr("data-src").ifBlank { attr("src") } }
             ?: doc.selectFirst("script:containsData(embedUrl)")
                 ?.data()
                 ?.substringAfter("\"embedUrl\": \"")

--- a/src/tr/animeler/src/eu/kanade/tachiyomi/animeextension/tr/animeler/dto/AnimelerDto.kt
+++ b/src/tr/animeler/src/eu/kanade/tachiyomi/animeextension/tr/animeler/dto/AnimelerDto.kt
@@ -5,10 +5,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonPrimitive
 
 @Serializable
-data class SearchResponseDto(
-    val data: List<SimpleAnimeDto>,
-    val pages: Int,
-)
+data class SearchResponseDto(val data: String, val pages: Int)
 
 @Serializable
 data class PostDto(
@@ -19,17 +16,6 @@ data class PostDto(
 @Serializable
 data class ThumbnailDto(private val featured_url: JsonPrimitive) {
     val url = if (featured_url.isString) featured_url.content else null
-}
-
-@Serializable
-data class SimpleAnimeDto(
-    val url: String,
-    val post: PostDto,
-    private val image: String = "",
-    private val images: ThumbnailDto? = null,
-) {
-    val thumbnail = image.ifEmpty { images?.url }
-    val title = post.post_title
 }
 
 @Serializable


### PR DESCRIPTION
Related with #2931 

Note: The extractor is now geo-blocked to turkey, and I'm too lazy to install a VPN, so I had to ask @EfeDevirgen to test it.
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
