### PR TITLE
Update Domain for extension OtakuDesu

### DIFF
--- a/src/id/otakudesu/src/eu/kanade/tachiyomi/animeextension/id/otakudesu/OtakuDesu.kt
+++ b/src/id/otakudesu/src/eu/kanade/tachiyomi/animeextension/id/otakudesu/OtakuDesu.kt
@@ -34,7 +34,7 @@ class OtakuDesu : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override val name = "OtakuDesu"
 
-    override val baseUrl = "https://otakudesu.media"
+    override val baseUrl = "https://otakudesu.cloud"
 
     override val lang = "id"
 

--- a/src/id/samehadaku/build.gradle
+++ b/src/id/samehadaku/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Samehadaku'
     extClass = '.Samehadaku'
-    extVersionCode = 6
+    extVersionCode = 7
 }
 
 apply from: "$rootDir/common.gradle"


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension

closes #2964 
