### PR TITLE
refactor: remove BuildConfig from preference keys

### DIFF
--- a/src/ar/arabseed/build.gradle
+++ b/src/ar/arabseed/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Arab Seed'
     extClass = '.ArabSeed'
-    extVersionCode = 11
+    extVersionCode = 12
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ar/arabseed/src/eu/kanade/tachiyomi/animeextension/ar/arabseed/ArabSeed.kt
+++ b/src/ar/arabseed/src/eu/kanade/tachiyomi/animeextension/ar/arabseed/ArabSeed.kt
@@ -28,6 +28,8 @@ class ArabSeed : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override val name = "عرب سيد"
 
+    // TODO: Check frequency of url changes to potentially
+    // add back overridable baseurl preference
     override val baseUrl = "https://m.asd.homes"
 
     override val lang = "ar"

--- a/src/ar/arabseed/src/eu/kanade/tachiyomi/animeextension/ar/arabseed/ArabSeed.kt
+++ b/src/ar/arabseed/src/eu/kanade/tachiyomi/animeextension/ar/arabseed/ArabSeed.kt
@@ -1,11 +1,8 @@
 package eu.kanade.tachiyomi.animeextension.ar.arabseed
 
 import android.app.Application
-import android.widget.Toast
-import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
-import eu.kanade.tachiyomi.animeextension.BuildConfig
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilter
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
@@ -31,9 +28,7 @@ class ArabSeed : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override val name = "عرب سيد"
 
-    override val baseUrl by lazy {
-        preferences.getString(PREF_DOMAIN_KEY, PREF_DOMAIN_DEFAULT)!!
-    }
+    override val baseUrl = "https://m.asd.homes"
 
     override val lang = "ar"
 
@@ -209,23 +204,6 @@ class ArabSeed : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     // =============================== Preferences ===============================
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
-        val defaultDomainPref = EditTextPreference(screen.context).apply {
-            key = PREF_DOMAIN_KEY
-            title = PREF_DOMAIN_TITLE
-            dialogTitle = PREF_DOMAIN_DIALOG_TITLE
-            dialogMessage = PREF_DOMAIN_DIALOG_MESSAGE
-            setDefaultValue(PREF_DOMAIN_DEFAULT)
-            summary = PREF_DOMAIN_SUMMARY
-
-            setOnPreferenceChangeListener { _, newValue ->
-                runCatching {
-                    val value = (newValue as String).ifEmpty { PREF_DOMAIN_DEFAULT }
-                    Toast.makeText(screen.context, PREF_DOMAIN_TOAST, Toast.LENGTH_LONG).show()
-                    preferences.edit().putString(key, value).commit()
-                }.getOrDefault(false)
-            }
-        }
-
         val videoQualityPref = ListPreference(screen.context).apply {
             key = PREF_QUALITY_KEY
             title = PREF_QUALITY_TITLE
@@ -241,21 +219,11 @@ class ArabSeed : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
                 preferences.edit().putString(key, entry).commit()
             }
         }
-        screen.addPreference(defaultDomainPref)
         screen.addPreference(videoQualityPref)
     }
 
     // ============================= Utilities ==============================
     companion object {
-        // From egydead(ar)
-        private const val PREF_DOMAIN_KEY = "default_domain_v${BuildConfig.VERSION_NAME}"
-        private const val PREF_DOMAIN_TITLE = "Override default domain with a custom, different one"
-        private const val PREF_DOMAIN_DEFAULT = "https://m95.arabseed.show"
-        private const val PREF_DOMAIN_DIALOG_TITLE = "Enter custom domain"
-        private const val PREF_DOMAIN_DIALOG_MESSAGE = "Default/Original domain: $PREF_DOMAIN_DEFAULT"
-        private const val PREF_DOMAIN_SUMMARY = "You can change the site domain from here"
-        private const val PREF_DOMAIN_TOAST = "Restart Aniyomi to apply changes"
-
         private const val PREF_QUALITY_KEY = "preferred_quality"
         private const val PREF_QUALITY_TITLE = "Preferred quality"
         private const val PREF_QUALITY_DEFAULT = "1080"

--- a/src/ar/egydead/build.gradle
+++ b/src/ar/egydead/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Egy Dead'
     extClass = '.EgyDead'
-    extVersionCode = 11
+    extVersionCode = 12
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ar/egydead/src/eu/kanade/tachiyomi/animeextension/ar/egydead/EgyDead.kt
+++ b/src/ar/egydead/src/eu/kanade/tachiyomi/animeextension/ar/egydead/EgyDead.kt
@@ -31,6 +31,8 @@ class EgyDead : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override val name = "Egy Dead"
 
+    // TODO: Check frequency of url changes to potentially
+    // add back overridable baseurl preference
     override val baseUrl = "https://egydead.space"
 
     override val lang = "ar"

--- a/src/ar/egydead/src/eu/kanade/tachiyomi/animeextension/ar/egydead/EgyDead.kt
+++ b/src/ar/egydead/src/eu/kanade/tachiyomi/animeextension/ar/egydead/EgyDead.kt
@@ -2,11 +2,8 @@ package eu.kanade.tachiyomi.animeextension.ar.egydead
 
 import android.app.Application
 import android.content.SharedPreferences
-import android.widget.Toast
-import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
-import eu.kanade.tachiyomi.animeextension.BuildConfig
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilter
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
@@ -29,15 +26,12 @@ import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
-import java.lang.Exception
 
 class EgyDead : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override val name = "Egy Dead"
 
-    override val baseUrl by lazy {
-        getPrefHostUrl(preferences)
-    }
+    override val baseUrl = "https://egydead.space"
 
     override val lang = "ar"
 
@@ -297,32 +291,7 @@ class EgyDead : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     // ================================== preferences ==================================
 
-    private fun getPrefHostUrl(preferences: SharedPreferences): String = preferences.getString(
-        "default_domain_v${BuildConfig.VERSION_CODE}",
-        "https://egydead.space/",
-    )!!.trim()
-
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
-        val defaultDomain = EditTextPreference(screen.context).apply {
-            key = "default_domain"
-            title = "Override default domain with a different one"
-            summary = getPrefHostUrl(preferences)
-            this.setDefaultValue(getPrefHostUrl(preferences))
-            dialogTitle = "Enter default domain"
-            dialogMessage = "You can change the site domain from here"
-
-            setOnPreferenceChangeListener { _, newValue ->
-                try {
-                    val res = preferences.edit().putString("default_domain", newValue as String).commit()
-                    Toast.makeText(screen.context, "Restart Aniyomi to apply changes", Toast.LENGTH_LONG).show()
-                    res
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                    false
-                }
-            }
-        }
-
         val videoQualityPref = ListPreference(screen.context).apply {
             key = "preferred_quality"
             title = "Preferred quality"
@@ -338,7 +307,6 @@ class EgyDead : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
                 preferences.edit().putString(key, entry).commit()
             }
         }
-        screen.addPreference(defaultDomain)
         screen.addPreference(videoQualityPref)
     }
 

--- a/src/ar/tuktukcinema/build.gradle
+++ b/src/ar/tuktukcinema/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Tuktuk Cinema'
     extClass = '.Tuktukcinema'
-    extVersionCode = 17
+    extVersionCode = 18
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ar/tuktukcinema/src/eu/kanade/tachiyomi/animeextension/ar/tuktukcinema/Tuktukcinema.kt
+++ b/src/ar/tuktukcinema/src/eu/kanade/tachiyomi/animeextension/ar/tuktukcinema/Tuktukcinema.kt
@@ -2,12 +2,9 @@ package eu.kanade.tachiyomi.animeextension.ar.tuktukcinema
 
 import android.app.Application
 import android.content.SharedPreferences
-import android.widget.Toast
-import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
 import dev.datlag.jsunpacker.JsUnpacker
-import eu.kanade.tachiyomi.animeextension.BuildConfig
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilter
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
@@ -30,15 +27,12 @@ import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
-import java.lang.Exception
 
 class Tuktukcinema : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override val name = "توك توك سينما"
 
-    override val baseUrl by lazy {
-        getPrefHostUrl(preferences)
-    }
+    override val baseUrl = "https://w.tuktokcinema.com"
 
     override val lang = "ar"
 
@@ -292,33 +286,7 @@ class Tuktukcinema : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
         CatUnit("مسلسلات هندى", "category/series-9/مسلسلات-هندي/"),
     )
 
-    // preferred quality settings
-    private fun getPrefHostUrl(preferences: SharedPreferences): String = preferences.getString(
-        "default_domain_v${BuildConfig.VERSION_CODE}",
-        "https://ww.tuktukcima.com/",
-    )!!.trim()
-
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
-        val defaultDomain = EditTextPreference(screen.context).apply {
-            key = "default_domain"
-            title = "Enter default domain"
-            summary = getPrefHostUrl(preferences)
-            this.setDefaultValue(getPrefHostUrl(preferences))
-            dialogTitle = "Default domain"
-            dialogMessage = "You can change the site domain from here"
-
-            setOnPreferenceChangeListener { _, newValue ->
-                try {
-                    val res = preferences.edit().putString("default_domain", newValue as String).commit()
-                    Toast.makeText(screen.context, "Restart Aniyomi to apply changes", Toast.LENGTH_LONG).show()
-                    res
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                    false
-                }
-            }
-        }
-
         val videoQualityPref = ListPreference(screen.context).apply {
             key = "preferred_quality"
             title = "Preferred quality"
@@ -334,7 +302,6 @@ class Tuktukcinema : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
                 preferences.edit().putString(key, entry).commit()
             }
         }
-        screen.addPreference(defaultDomain)
         screen.addPreference(videoQualityPref)
     }
 }

--- a/src/ar/tuktukcinema/src/eu/kanade/tachiyomi/animeextension/ar/tuktukcinema/Tuktukcinema.kt
+++ b/src/ar/tuktukcinema/src/eu/kanade/tachiyomi/animeextension/ar/tuktukcinema/Tuktukcinema.kt
@@ -32,6 +32,8 @@ class Tuktukcinema : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override val name = "توك توك سينما"
 
+    // TODO: Check frequency of url changes to potentially
+    // add back overridable baseurl preference
     override val baseUrl = "https://w.tuktokcinema.com"
 
     override val lang = "ar"

--- a/src/en/ask4movie/build.gradle
+++ b/src/en/ask4movie/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Ask4Movie'
     extClass = '.Ask4Movie'
-    extVersionCode = 11
+    extVersionCode = 12
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/ask4movie/src/eu/kanade/tachiyomi/animeextension/en/ask4movie/Ask4Movie.kt
+++ b/src/en/ask4movie/src/eu/kanade/tachiyomi/animeextension/en/ask4movie/Ask4Movie.kt
@@ -2,11 +2,6 @@ package eu.kanade.tachiyomi.animeextension.en.ask4movie
 
 import android.app.Application
 import android.content.SharedPreferences
-import android.widget.Toast
-import androidx.preference.EditTextPreference
-import androidx.preference.PreferenceScreen
-import eu.kanade.tachiyomi.animeextension.BuildConfig
-import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilter
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
 import eu.kanade.tachiyomi.animesource.model.AnimesPage
@@ -24,19 +19,15 @@ import org.jsoup.nodes.Element
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
-class Ask4Movie : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
+class Ask4Movie : ParsedAnimeHttpSource() {
 
     override val name = "Ask4Movie"
 
-    override val baseUrl by lazy { preferences.getString(PREF_DOMAIN_KEY, PREF_DOMAIN_DEFAULT)!! }
+    override val baseUrl = "https://ask4movie.li"
 
     override val lang = "en"
 
     override val supportsLatest = true
-
-    private val preferences: SharedPreferences by lazy {
-        Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
-    }
 
     // ============================== Popular ===============================
 
@@ -189,32 +180,6 @@ class Ask4Movie : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
         } else {
             "page/$this"
         }
-    }
-
-    companion object {
-        private val PREF_DOMAIN_KEY = "preferred_domain_name_v${BuildConfig.VERSION_NAME}"
-        private const val PREF_DOMAIN_TITLE = "Override BaseUrl"
-        private const val PREF_DOMAIN_DEFAULT = "https://ask4movie.li"
-        private const val PREF_DOMAIN_SUMMARY = "For temporary uses. Updating the extension will erase this setting."
-    }
-
-    // ============================== Settings ==============================
-
-    override fun setupPreferenceScreen(screen: PreferenceScreen) {
-        EditTextPreference(screen.context).apply {
-            key = PREF_DOMAIN_KEY
-            title = PREF_DOMAIN_TITLE
-            summary = PREF_DOMAIN_SUMMARY
-            dialogTitle = PREF_DOMAIN_TITLE
-            dialogMessage = "Default: $PREF_DOMAIN_DEFAULT"
-            setDefaultValue(PREF_DOMAIN_DEFAULT)
-
-            setOnPreferenceChangeListener { _, newValue ->
-                val newValueString = newValue as String
-                Toast.makeText(screen.context, "Restart Aniyomi to apply new setting.", Toast.LENGTH_LONG).show()
-                preferences.edit().putString(key, newValueString.trim()).commit()
-            }
-        }.also(screen::addPreference)
     }
 
     // ============================== Filters ===============================

--- a/src/en/ask4movie/src/eu/kanade/tachiyomi/animeextension/en/ask4movie/Ask4Movie.kt
+++ b/src/en/ask4movie/src/eu/kanade/tachiyomi/animeextension/en/ask4movie/Ask4Movie.kt
@@ -1,7 +1,5 @@
 package eu.kanade.tachiyomi.animeextension.en.ask4movie
 
-import android.app.Application
-import android.content.SharedPreferences
 import eu.kanade.tachiyomi.animesource.model.AnimeFilter
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
 import eu.kanade.tachiyomi.animesource.model.AnimesPage
@@ -16,8 +14,6 @@ import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
-import uy.kohesive.injekt.Injekt
-import uy.kohesive.injekt.api.get
 
 class Ask4Movie : ParsedAnimeHttpSource() {
 

--- a/src/en/ask4movie/src/eu/kanade/tachiyomi/animeextension/en/ask4movie/Ask4Movie.kt
+++ b/src/en/ask4movie/src/eu/kanade/tachiyomi/animeextension/en/ask4movie/Ask4Movie.kt
@@ -19,6 +19,8 @@ class Ask4Movie : ParsedAnimeHttpSource() {
 
     override val name = "Ask4Movie"
 
+    // TODO: Check frequency of url changes to potentially
+    // add back overridable baseurl preference
     override val baseUrl = "https://ask4movie.li"
 
     override val lang = "en"

--- a/src/en/dramacool/build.gradle
+++ b/src/en/dramacool/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'DramaCool'
     extClass = '.DramaCool'
-    extVersionCode = 47
+    extVersionCode = 48
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/dramacool/src/eu/kanade/tachiyomi/animeextension/en/dramacool/DramaCool.kt
+++ b/src/en/dramacool/src/eu/kanade/tachiyomi/animeextension/en/dramacool/DramaCool.kt
@@ -1,11 +1,8 @@
 package eu.kanade.tachiyomi.animeextension.en.dramacool
 
 import android.app.Application
-import android.widget.Toast
-import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
-import eu.kanade.tachiyomi.animeextension.BuildConfig
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
 import eu.kanade.tachiyomi.animesource.model.SAnime
@@ -23,7 +20,6 @@ import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
-import java.lang.Exception
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -31,9 +27,7 @@ class DramaCool : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override val name = "DramaCool"
 
-    private val defaultBaseUrl = "https://dramacool.pa"
-
-    override val baseUrl by lazy { getPrefBaseUrl() }
+    override val baseUrl = "https://dramacool.com.pa"
 
     override val lang = "en"
 
@@ -150,26 +144,6 @@ class DramaCool : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     // ============================== Settings ==============================
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
-        EditTextPreference(screen.context).apply {
-            key = BASE_URL_PREF_TITLE
-            title = BASE_URL_PREF_TITLE
-            summary = BASE_URL_PREF_SUMMARY
-            setDefaultValue(defaultBaseUrl)
-            dialogTitle = BASE_URL_PREF_TITLE
-            dialogMessage = "Default: $defaultBaseUrl"
-
-            setOnPreferenceChangeListener { _, newValue ->
-                try {
-                    val res = preferences.edit().putString(BASE_URL_PREF, newValue as String).commit()
-                    Toast.makeText(screen.context, RESTART_ANIYOMI, Toast.LENGTH_LONG).show()
-                    res
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                    false
-                }
-            }
-        }.also(screen::addPreference)
-
         ListPreference(screen.context).apply {
             key = PREF_QUALITY_KEY
             title = PREF_QUALITY_TITLE
@@ -212,17 +186,7 @@ class DramaCool : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
             .getOrNull() ?: 0L
     }
 
-    private fun getPrefBaseUrl(): String = preferences.getString(BASE_URL_PREF, defaultBaseUrl)!!
-
     companion object {
-        private const val RESTART_ANIYOMI = "Restart Aniyomi to apply new setting."
-
-        private const val BASE_URL_PREF_TITLE = "Override BaseUrl"
-
-        private val BASE_URL_PREF = "overrideBaseUrl_v${BuildConfig.VERSION_CODE}"
-
-        private const val BASE_URL_PREF_SUMMARY = "For temporary uses. Update extension will erase this setting."
-
         private val DATE_FORMATTER by lazy {
             SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ENGLISH)
         }

--- a/src/en/dramacool/src/eu/kanade/tachiyomi/animeextension/en/dramacool/DramaCool.kt
+++ b/src/en/dramacool/src/eu/kanade/tachiyomi/animeextension/en/dramacool/DramaCool.kt
@@ -27,6 +27,8 @@ class DramaCool : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override val name = "DramaCool"
 
+    // TODO: Check frequency of url changes to potentially
+    // add back overridable baseurl preference
     override val baseUrl = "https://dramacool.com.pa"
 
     override val lang = "en"

--- a/src/en/gogoanime/build.gradle
+++ b/src/en/gogoanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Gogoanime'
     extClass = '.GogoAnime'
-    extVersionCode = 80
+    extVersionCode = 81
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/gogoanime/src/eu/kanade/tachiyomi/animeextension/en/gogoanime/GogoAnime.kt
+++ b/src/en/gogoanime/src/eu/kanade/tachiyomi/animeextension/en/gogoanime/GogoAnime.kt
@@ -1,12 +1,9 @@
 package eu.kanade.tachiyomi.animeextension.en.gogoanime
 
 import android.app.Application
-import android.widget.Toast
-import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.MultiSelectListPreference
 import androidx.preference.PreferenceScreen
-import eu.kanade.tachiyomi.animeextension.BuildConfig
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
 import eu.kanade.tachiyomi.animesource.model.SAnime
@@ -31,10 +28,7 @@ class GogoAnime : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override val name = "Gogoanime"
 
-    override val baseUrl by lazy {
-        preferences.getString(PREF_DOMAIN_KEY, PREF_DOMAIN_DEFAULT).orEmpty()
-            .trim().ifBlank { PREF_DOMAIN_DEFAULT }
-    }
+    override val baseUrl = "https://anitaku.to"
 
     override val lang = "en"
 
@@ -236,12 +230,6 @@ class GogoAnime : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
             "filelions",
         )
 
-        private const val PREF_DOMAIN_KEY = "preferred_domain_name_v${BuildConfig.VERSION_CODE}"
-        private const val PREF_DOMAIN_TITLE = "Override BaseUrl"
-        private const val PREF_DOMAIN_DEFAULT = "https://anitaku.to"
-        private const val PREF_DOMAIN_SUMMARY = "For temporary uses. Updating the extension will erase this setting."
-        private const val PREF_DOMAIN_DIALOG_MESSAGE = "Default: $PREF_DOMAIN_DEFAULT"
-
         private const val PREF_QUALITY_KEY = "preferred_quality"
         private const val PREF_QUALITY_TITLE = "Preferred quality"
         private const val PREF_QUALITY_DEFAULT = "1080"
@@ -259,23 +247,6 @@ class GogoAnime : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     // ============================== Settings ==============================
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
-        EditTextPreference(screen.context).apply {
-            key = PREF_DOMAIN_KEY
-            title = PREF_DOMAIN_TITLE
-            dialogTitle = PREF_DOMAIN_TITLE
-            dialogMessage = PREF_DOMAIN_DIALOG_MESSAGE
-            setDefaultValue(PREF_DOMAIN_DEFAULT)
-            summary = PREF_DOMAIN_SUMMARY
-
-            setOnPreferenceChangeListener { _, newValue ->
-                runCatching {
-                    val value = (newValue as String).trim().ifBlank { PREF_DOMAIN_DEFAULT }
-                    Toast.makeText(screen.context, "Restart Aniyomi to apply new setting.", Toast.LENGTH_LONG).show()
-                    preferences.edit().putString(key, value).commit()
-                }.getOrDefault(false)
-            }
-        }.also(screen::addPreference)
-
         ListPreference(screen.context).apply {
             key = PREF_QUALITY_KEY
             title = PREF_QUALITY_TITLE

--- a/src/en/gogoanime/src/eu/kanade/tachiyomi/animeextension/en/gogoanime/GogoAnime.kt
+++ b/src/en/gogoanime/src/eu/kanade/tachiyomi/animeextension/en/gogoanime/GogoAnime.kt
@@ -28,6 +28,8 @@ class GogoAnime : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override val name = "Gogoanime"
 
+    // TODO: Check frequency of url changes to potentially
+    // add back overridable baseurl preference
     override val baseUrl = "https://anitaku.to"
 
     override val lang = "en"

--- a/src/en/multimovies/build.gradle
+++ b/src/en/multimovies/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Multimovies'
     extClass = '.Multimovies'
     themePkg = 'dooplay'
-    baseUrl = 'https://multimovies.live'
-    overrideVersionCode = 15
+    baseUrl = 'https://multimovies.art'
+    overrideVersionCode = 16
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/multimovies/src/eu/kanade/tachiyomi/animeextension/en/multimovies/Multimovies.kt
+++ b/src/en/multimovies/src/eu/kanade/tachiyomi/animeextension/en/multimovies/Multimovies.kt
@@ -27,6 +27,8 @@ class Multimovies : DooPlay(
     "Multimovies",
     "https://multimovies.art",
 ) {
+    // TODO: Check frequency of url changes to potentially
+    // add back overridable baseurl preference
     override val preferences: SharedPreferences by lazy {
         Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
     }

--- a/src/en/multimovies/src/eu/kanade/tachiyomi/animeextension/en/multimovies/Multimovies.kt
+++ b/src/en/multimovies/src/eu/kanade/tachiyomi/animeextension/en/multimovies/Multimovies.kt
@@ -2,11 +2,8 @@ package eu.kanade.tachiyomi.animeextension.en.multimovies
 
 import android.app.Application
 import android.content.SharedPreferences
-import android.widget.Toast
-import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
-import eu.kanade.tachiyomi.animeextension.BuildConfig
 import eu.kanade.tachiyomi.animeextension.en.multimovies.extractors.AutoEmbedExtractor
 import eu.kanade.tachiyomi.animeextension.en.multimovies.extractors.MultimoviesCloudExtractor
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
@@ -28,13 +25,8 @@ import uy.kohesive.injekt.api.get
 class Multimovies : DooPlay(
     "en",
     "Multimovies",
-    "https://multimovies.live",
+    "https://multimovies.art",
 ) {
-
-    private val defaultBaseUrl = "https://multimovies.live"
-
-    override val baseUrl by lazy { getPrefBaseUrl() }
-
     override val preferences: SharedPreferences by lazy {
         Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
     }
@@ -156,19 +148,6 @@ class Multimovies : DooPlay(
     // ============================== Settings ==============================
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
-        EditTextPreference(screen.context).apply {
-            key = BASE_URL_PREF
-            title = BASE_URL_PREF_TITLE
-            summary = BASE_URL_PREF_SUMMARY
-            this.setDefaultValue(defaultBaseUrl)
-            dialogTitle = BASE_URL_PREF_TITLE
-
-            setOnPreferenceChangeListener { _, _ ->
-                Toast.makeText(screen.context, RESTART_ANIYOMI, Toast.LENGTH_LONG).show()
-                true
-            }
-        }.also(screen::addPreference)
-
         ListPreference(screen.context).apply {
             key = PREF_SERVER_KEY
             title = PREF_SERVER_TITLE
@@ -189,18 +168,11 @@ class Multimovies : DooPlay(
 
     // ============================= Utilities ==============================
 
-    private fun getPrefBaseUrl(): String = preferences.getString(BASE_URL_PREF, defaultBaseUrl)!!
-
     private inline fun <reified R> AnimeFilterList.getFirst(): R {
         return first { it is R } as R
     }
 
     companion object {
-        private const val RESTART_ANIYOMI = "Restart Aniyomi to apply new setting."
-        private const val BASE_URL_PREF_TITLE = "Override BaseUrl"
-        private val BASE_URL_PREF = "overrideBaseUrl_v${BuildConfig.VERSION_CODE}"
-        private const val BASE_URL_PREF_SUMMARY = "For temporary uses. Updating the extension will erase this setting."
-
         private const val PREF_SERVER_KEY = "preferred_server"
         private const val PREF_SERVER_TITLE = "Preferred Server"
         private const val PREF_SERVER_DEFAULT = "multimovies"

--- a/src/en/ripcrabbyanime/build.gradle
+++ b/src/en/ripcrabbyanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Ripcrabbyanime'
     extClass = '.Ripcrabbyanime'
-    extVersionCode = 11
+    extVersionCode = 12
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/ripcrabbyanime/src/eu/kanade/tachiyomi/animeextension/en/ripcrabbyanime/Ripcrabbyanime.kt
+++ b/src/en/ripcrabbyanime/src/eu/kanade/tachiyomi/animeextension/en/ripcrabbyanime/Ripcrabbyanime.kt
@@ -2,11 +2,8 @@ package eu.kanade.tachiyomi.animeextension.en.ripcrabbyanime
 
 import android.app.Application
 import android.content.SharedPreferences
-import android.widget.Toast
-import androidx.preference.EditTextPreference
 import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreferenceCompat
-import eu.kanade.tachiyomi.animeextension.BuildConfig
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilter
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
@@ -40,7 +37,7 @@ class Ripcrabbyanime : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override val id = 623659475482363776
 
-    override val baseUrl by lazy { preferences.getString(PREF_DOMAIN_KEY, PREF_DOMAIN_DEFAULT)!! }
+    override val baseUrl = "https://ripcrabbyanime.com"
 
     override val lang = "en"
 
@@ -413,11 +410,6 @@ class Ripcrabbyanime : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
         private const val TRIM_EPISODE_NAME_KEY = "trim_episode"
         private const val TRIM_EPISODE_NAME_DEFAULT = true
-
-        private val PREF_DOMAIN_KEY = "preferred_domain_name_v${BuildConfig.VERSION_CODE}"
-        private const val PREF_DOMAIN_TITLE = "Override BaseUrl"
-        private const val PREF_DOMAIN_DEFAULT = "https://ripcrabbyanimes.com"
-        private const val PREF_DOMAIN_SUMMARY = "For temporary uses. Updating the extension will erase this setting."
     }
 
     private val SharedPreferences.trimEpisodeName
@@ -426,21 +418,6 @@ class Ripcrabbyanime : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
     // ============================== Settings ==============================
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
-        EditTextPreference(screen.context).apply {
-            key = PREF_DOMAIN_KEY
-            title = PREF_DOMAIN_TITLE
-            summary = PREF_DOMAIN_SUMMARY
-            dialogTitle = PREF_DOMAIN_TITLE
-            dialogMessage = "Default: $PREF_DOMAIN_DEFAULT"
-            setDefaultValue(PREF_DOMAIN_DEFAULT)
-
-            setOnPreferenceChangeListener { _, newValue ->
-                val newValueString = newValue as String
-                Toast.makeText(screen.context, "Restart Aniyomi to apply new setting.", Toast.LENGTH_LONG).show()
-                preferences.edit().putString(key, newValueString.trim()).commit()
-            }
-        }.also(screen::addPreference)
-
         SwitchPreferenceCompat(screen.context).apply {
             key = TRIM_EPISODE_NAME_KEY
             title = "Trim info from episode name"

--- a/src/en/ripcrabbyanime/src/eu/kanade/tachiyomi/animeextension/en/ripcrabbyanime/Ripcrabbyanime.kt
+++ b/src/en/ripcrabbyanime/src/eu/kanade/tachiyomi/animeextension/en/ripcrabbyanime/Ripcrabbyanime.kt
@@ -37,6 +37,8 @@ class Ripcrabbyanime : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override val id = 623659475482363776
 
+    // TODO: Check frequency of url changes to potentially
+    // add back overridable baseurl preference
     override val baseUrl = "https://ripcrabbyanime.com"
 
     override val lang = "en"

--- a/src/hi/yomovies/build.gradle
+++ b/src/hi/yomovies/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'YoMovies'
     extClass = '.YoMovies'
-    extVersionCode = 8
+    extVersionCode = 9
     isNsfw = true
 }
 

--- a/src/hi/yomovies/src/eu/kanade/tachiyomi/animeextension/hi/yomovies/YoMovies.kt
+++ b/src/hi/yomovies/src/eu/kanade/tachiyomi/animeextension/hi/yomovies/YoMovies.kt
@@ -29,6 +29,8 @@ class YoMovies : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override val name = "YoMovies"
 
+    // TODO: Check frequency of url changes to potentially
+    // add back overridable baseurl preference
     override val baseUrl = "https://yomovies.town"
 
     override val lang = "hi"

--- a/src/hi/yomovies/src/eu/kanade/tachiyomi/animeextension/hi/yomovies/YoMovies.kt
+++ b/src/hi/yomovies/src/eu/kanade/tachiyomi/animeextension/hi/yomovies/YoMovies.kt
@@ -1,11 +1,8 @@
 package eu.kanade.tachiyomi.animeextension.hi.yomovies
 
 import android.app.Application
-import android.widget.Toast
-import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
-import eu.kanade.tachiyomi.animeextension.BuildConfig
 import eu.kanade.tachiyomi.animeextension.hi.yomovies.extractors.MinoplresExtractor
 import eu.kanade.tachiyomi.animeextension.hi.yomovies.extractors.MovembedExtractor
 import eu.kanade.tachiyomi.animeextension.hi.yomovies.extractors.SpeedostreamExtractor
@@ -32,7 +29,7 @@ class YoMovies : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override val name = "YoMovies"
 
-    override val baseUrl by lazy { preferences.getString(PREF_DOMAIN_KEY, PREF_DOMAIN_DEFAULT)!! }
+    override val baseUrl = "https://yomovies.town"
 
     override val lang = "hi"
 
@@ -209,11 +206,6 @@ class YoMovies : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
     }
 
     companion object {
-        private val PREF_DOMAIN_KEY = "preferred_domain_name_v${BuildConfig.VERSION_CODE}"
-        private const val PREF_DOMAIN_TITLE = "Override BaseUrl"
-        private const val PREF_DOMAIN_DEFAULT = "https://yomovies.support"
-        private const val PREF_DOMAIN_SUMMARY = "For temporary uses. Updating the extension will erase this setting."
-
         private const val PREF_QUALITY_KEY = "preferred_quality"
         private const val PREF_QUALITY_DEFAULT = "1080"
     }
@@ -221,21 +213,6 @@ class YoMovies : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
     // ============================== Settings ==============================
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
-        EditTextPreference(screen.context).apply {
-            key = PREF_DOMAIN_KEY
-            title = PREF_DOMAIN_TITLE
-            summary = PREF_DOMAIN_SUMMARY
-            dialogTitle = PREF_DOMAIN_TITLE
-            dialogMessage = "Default: $PREF_DOMAIN_DEFAULT"
-            setDefaultValue(PREF_DOMAIN_DEFAULT)
-
-            setOnPreferenceChangeListener { _, newValue ->
-                val newValueString = newValue as String
-                Toast.makeText(screen.context, "Restart Aniyomi to apply new setting.", Toast.LENGTH_LONG).show()
-                preferences.edit().putString(key, newValueString.trim()).commit()
-            }
-        }.also(screen::addPreference)
-
         ListPreference(screen.context).apply {
             key = PREF_QUALITY_KEY
             title = "Preferred quality"

--- a/src/it/animeunity/build.gradle
+++ b/src/it/animeunity/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimeUnity'
     extClass = '.AnimeUnity'
-    extVersionCode = 7
+    extVersionCode = 8
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/it/animeunity/src/eu/kanade/tachiyomi/animeextension/it/animeunity/AnimeUnity.kt
+++ b/src/it/animeunity/src/eu/kanade/tachiyomi/animeextension/it/animeunity/AnimeUnity.kt
@@ -3,11 +3,8 @@ package eu.kanade.tachiyomi.animeextension.it.animeunity
 import android.annotation.SuppressLint
 import android.app.Application
 import android.content.SharedPreferences
-import android.widget.Toast
-import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
-import eu.kanade.tachiyomi.animeextension.BuildConfig
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
 import eu.kanade.tachiyomi.animesource.model.AnimesPage
@@ -39,7 +36,7 @@ class AnimeUnity :
     ConfigurableAnimeSource {
     override val name = "AnimeUnity"
 
-    override val baseUrl by lazy { preferences.getString(PREF_DOMAIN_KEY, PREF_DOMAIN_DEFAULT)!! }
+    override val baseUrl = "https://www.animeunity.to"
 
     override val lang = "it"
 
@@ -491,11 +488,6 @@ class AnimeUnity :
     }
 
     companion object {
-        private val PREF_DOMAIN_KEY = "preferred_domain_name_v${BuildConfig.VERSION_CODE}"
-        private const val PREF_DOMAIN_TITLE = "Override BaseUrl"
-        private const val PREF_DOMAIN_DEFAULT = "https://www.animeunity.to"
-        private const val PREF_DOMAIN_SUMMARY = "For temporary uses. Updating the extension will erase this setting."
-
         private const val PREF_QUALITY_KEY = "preferred_quality"
         private const val PREF_QUALITY_DEFAULT = "1080"
     }
@@ -503,22 +495,6 @@ class AnimeUnity :
     // ============================== Settings ==============================
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
-        EditTextPreference(screen.context)
-            .apply {
-                key = PREF_DOMAIN_KEY
-                title = PREF_DOMAIN_TITLE
-                summary = PREF_DOMAIN_SUMMARY
-                dialogTitle = PREF_DOMAIN_TITLE
-                dialogMessage = "Default: $PREF_DOMAIN_DEFAULT"
-                setDefaultValue(PREF_DOMAIN_DEFAULT)
-
-                setOnPreferenceChangeListener { _, newValue ->
-                    val newValueString = newValue as String
-                    Toast.makeText(screen.context, "Restart Aniyomi to apply new setting.", Toast.LENGTH_LONG).show()
-                    preferences.edit().putString(key, newValueString.trim()).commit()
-                }
-            }.also(screen::addPreference)
-
         ListPreference(screen.context)
             .apply {
                 key = PREF_QUALITY_KEY

--- a/src/it/animeunity/src/eu/kanade/tachiyomi/animeextension/it/animeunity/AnimeUnity.kt
+++ b/src/it/animeunity/src/eu/kanade/tachiyomi/animeextension/it/animeunity/AnimeUnity.kt
@@ -36,6 +36,8 @@ class AnimeUnity :
     ConfigurableAnimeSource {
     override val name = "AnimeUnity"
 
+    // TODO: Check frequency of url changes to potentially
+    // add back overridable baseurl preference
     override val baseUrl = "https://www.animeunity.to"
 
     override val lang = "it"

--- a/src/it/animeworld/build.gradle
+++ b/src/it/animeworld/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'ANIMEWORLD.tv'
     extClass = '.ANIMEWORLD'
-    extVersionCode = 35
+    extVersionCode = 36
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/it/animeworld/src/eu/kanade/tachiyomi/animeextension/it/animeworld/ANIMEWORLD.kt
+++ b/src/it/animeworld/src/eu/kanade/tachiyomi/animeextension/it/animeworld/ANIMEWORLD.kt
@@ -2,11 +2,8 @@ package eu.kanade.tachiyomi.animeextension.it.animeworld
 
 import android.app.Application
 import android.content.SharedPreferences
-import android.widget.Toast
-import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
-import eu.kanade.tachiyomi.animeextension.BuildConfig
 import eu.kanade.tachiyomi.animeextension.it.animeworld.extractors.StreamHideExtractor
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilter
@@ -37,7 +34,7 @@ class ANIMEWORLD : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override val name = "ANIMEWORLD.tv"
 
-    override val baseUrl by lazy { preferences.getString(PREF_DOMAIN_KEY, PREF_DOMAIN_DEFAULT)!! }
+    override val baseUrl = "https://www.animeworld.so"
 
     override val lang = "it"
 
@@ -532,21 +529,6 @@ class ANIMEWORLD : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
                 preferences.edit().putString(key, entry).commit()
             }
         }.also(screen::addPreference)
-
-        EditTextPreference(screen.context).apply {
-            key = PREF_DOMAIN_KEY
-            title = PREF_DOMAIN_TITLE
-            summary = PREF_DOMAIN_SUMMARY
-            dialogTitle = PREF_DOMAIN_TITLE
-            dialogMessage = "Default: $PREF_DOMAIN_DEFAULT"
-            setDefaultValue(PREF_DOMAIN_DEFAULT)
-
-            setOnPreferenceChangeListener { _, newValue ->
-                val newValueString = newValue as String
-                Toast.makeText(screen.context, "Restart Aniyomi to apply new setting.", Toast.LENGTH_LONG).show()
-                preferences.edit().putString(key, newValueString.trim()).commit()
-            }
-        }.also(screen::addPreference)
     }
 
     // Utilities
@@ -555,11 +537,4 @@ class ANIMEWORLD : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
     data class ServerResponse(
         val target: String,
     )
-
-    companion object {
-        private val PREF_DOMAIN_KEY = "preferred_domain_name_v${BuildConfig.VERSION_CODE}"
-        private const val PREF_DOMAIN_TITLE = "Override BaseUrl"
-        private const val PREF_DOMAIN_DEFAULT = "https://www.animeworld.so"
-        private const val PREF_DOMAIN_SUMMARY = "For temporary uses. Updating the extension will erase this setting."
-    }
 }

--- a/src/it/animeworld/src/eu/kanade/tachiyomi/animeextension/it/animeworld/ANIMEWORLD.kt
+++ b/src/it/animeworld/src/eu/kanade/tachiyomi/animeextension/it/animeworld/ANIMEWORLD.kt
@@ -34,6 +34,8 @@ class ANIMEWORLD : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override val name = "ANIMEWORLD.tv"
 
+    // TODO: Check frequency of url changes to potentially
+    // add back overridable baseurl preference
     override val baseUrl = "https://www.animeworld.so"
 
     override val lang = "it"

--- a/src/it/streamingcommunity/build.gradle
+++ b/src/it/streamingcommunity/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'StreamingCommunity'
     extClass = '.StreamingCommunity'
-    extVersionCode = 2
+    extVersionCode = 3
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/it/streamingcommunity/src/eu/kanade/tachiyomi/animeextension/it/streamingcommunity/StreamingCommunity.kt
+++ b/src/it/streamingcommunity/src/eu/kanade/tachiyomi/animeextension/it/streamingcommunity/StreamingCommunity.kt
@@ -2,11 +2,8 @@ package eu.kanade.tachiyomi.animeextension.it.streamingcommunity
 
 import android.app.Application
 import android.content.SharedPreferences
-import android.widget.Toast
-import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
-import eu.kanade.tachiyomi.animeextension.BuildConfig
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilter
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
@@ -32,7 +29,7 @@ class StreamingCommunity : ConfigurableAnimeSource, AnimeHttpSource() {
 
     override val name = "StreamingCommunity"
 
-    override val baseUrl by lazy { preferences.getString(PREF_DOMAIN_KEY, PREF_DOMAIN_DEFAULT)!! }
+    override val baseUrl = "https://streamingcommunity.report"
 
     override val lang = "it"
 
@@ -345,11 +342,6 @@ class StreamingCommunity : ConfigurableAnimeSource, AnimeHttpSource() {
     }
 
     companion object {
-        private val PREF_DOMAIN_KEY = "preferred_domain_name_v${BuildConfig.VERSION_CODE}"
-        private const val PREF_DOMAIN_TITLE = "Override BaseUrl"
-        private const val PREF_DOMAIN_DEFAULT = "https://streamingcommunity.at"
-        private const val PREF_DOMAIN_SUMMARY = "For temporary uses. Updating the extension will erase this setting."
-
         private const val PREF_QUALITY_KEY = "preferred_quality"
         private const val PREF_QUALITY_DEFAULT = "720"
     }
@@ -357,21 +349,6 @@ class StreamingCommunity : ConfigurableAnimeSource, AnimeHttpSource() {
     // ============================== Settings ==============================
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
-        EditTextPreference(screen.context).apply {
-            key = PREF_DOMAIN_KEY
-            title = PREF_DOMAIN_TITLE
-            summary = PREF_DOMAIN_SUMMARY
-            dialogTitle = PREF_DOMAIN_TITLE
-            dialogMessage = "Default: $PREF_DOMAIN_DEFAULT"
-            setDefaultValue(PREF_DOMAIN_DEFAULT)
-
-            setOnPreferenceChangeListener { _, newValue ->
-                val newValueString = newValue as String
-                Toast.makeText(screen.context, "Restart Aniyomi to apply new setting.", Toast.LENGTH_LONG).show()
-                preferences.edit().putString(key, newValueString.trim()).commit()
-            }
-        }.also(screen::addPreference)
-
         ListPreference(screen.context).apply {
             key = PREF_QUALITY_KEY
             title = "Preferred quality"

--- a/src/it/streamingcommunity/src/eu/kanade/tachiyomi/animeextension/it/streamingcommunity/StreamingCommunity.kt
+++ b/src/it/streamingcommunity/src/eu/kanade/tachiyomi/animeextension/it/streamingcommunity/StreamingCommunity.kt
@@ -29,6 +29,8 @@ class StreamingCommunity : ConfigurableAnimeSource, AnimeHttpSource() {
 
     override val name = "StreamingCommunity"
 
+    // TODO: Check frequency of url changes to potentially
+    // add back overridable baseurl preference
     override val baseUrl = "https://streamingcommunity.report"
 
     override val lang = "it"


### PR DESCRIPTION
Using the version number as the key will leave a trail of obsolete preferences, which should be avoided. I don't mean to prevent overridable baseurls with this pr, it's just that they should be implemented in such a way that doesn't create unnecessary preference items. I also don't want to convert all to a new system, since a lot of extension appears to not have changed urls in a long time.