### PR TITLE
update: removed as player

### DIFF
--- a/src/fr/animesama/build.gradle
+++ b/src/fr/animesama/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Anime-Sama'
     extClass = '.AnimeSama'
-    extVersionCode = 8
+    extVersionCode = 9
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/fr/animesama/src/eu/kanade/tachiyomi/animeextension/fr/animesama/AnimeSama.kt
+++ b/src/fr/animesama/src/eu/kanade/tachiyomi/animeextension/fr/animesama/AnimeSama.kt
@@ -123,7 +123,6 @@ class AnimeSama : ConfigurableAnimeSource, AnimeHttpSource() {
             it.parallelCatchingFlatMap { playerUrl ->
                 with(playerUrl) {
                     when {
-                        contains("anime-sama.fr") -> listOf(Video(playerUrl, "${prefix}AS Player", playerUrl))
                         contains("sibnet.ru") -> SibnetExtractor(client).videosFromUrl(playerUrl, prefix)
                         contains("vk.") -> VkExtractor(client, headers).videosFromUrl(playerUrl, prefix)
                         contains("sendvid.com") -> SendvidExtractor(client, headers).videosFromUrl(playerUrl, prefix)


### PR DESCRIPTION
Removing Anime-Sama's own player since these dumbasses `rm -rf`'d their video server.
It seems it might be back later from what they say on Discord.

Removing it is required because their server now returns a 403 when trying to get the video file and that softlocks the app, even when selecting another player, it will load forever.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Have not changed source names
- [x] Have tested the modifications by compiling and running the extension through Android Studio
