### PR TITLE
fix(en/animepahe): use ddosguardinterceptor

### DIFF
--- a/src/en/animepahe/build.gradle
+++ b/src/en/animepahe/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimePahe'
     extClass = '.AnimePahe'
-    extVersionCode = 26
+    extVersionCode = 27
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -39,6 +39,12 @@ class AnimePahe : ConfigurableAnimeSource, AnimeHttpSource() {
         Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
     }
 
+    private val interceptor = DdosGuardInterceptor(network.client)
+
+    override val client = network.client.newBuilder()
+        .addInterceptor(interceptor)
+        .build()
+
     override val name = "AnimePahe"
 
     override val baseUrl by lazy {

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/DdosGuardInterceptor.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/DdosGuardInterceptor.kt
@@ -1,0 +1,72 @@
+package eu.kanade.tachiyomi.animeextension.en.animepahe
+
+import android.webkit.CookieManager
+import eu.kanade.tachiyomi.network.GET
+import okhttp3.Cookie
+import okhttp3.HttpUrl
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import okhttp3.Response
+
+class DdosGuardInterceptor(private val client: OkHttpClient) : Interceptor {
+
+    private val cookieManager by lazy { CookieManager.getInstance() }
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val originalRequest = chain.request()
+        val response = chain.proceed(originalRequest)
+
+        // Check if DDos-GUARD is on
+        if (response.code !in ERROR_CODES || response.header("Server") !in SERVER_CHECK) {
+            return response
+        }
+
+        response.close()
+        val cookies = cookieManager.getCookie(originalRequest.url.toString())
+        val oldCookie = if (cookies != null && cookies.isNotEmpty()) {
+            cookies.split(";").mapNotNull { Cookie.parse(originalRequest.url, it) }
+        } else {
+            emptyList()
+        }
+        val ddg2Cookie = oldCookie.firstOrNull { it.name == "__ddg2_" }
+        if (!ddg2Cookie?.value.isNullOrEmpty()) {
+            return chain.proceed(originalRequest)
+        }
+
+        val newCookie = getNewCookie(originalRequest.url) ?: return chain.proceed(originalRequest)
+        val newCookieHeader = buildString {
+            (oldCookie + newCookie).forEachIndexed { index, cookie ->
+                if (index > 0) append("; ")
+                append(cookie.name).append('=').append(cookie.value)
+            }
+        }
+
+        return chain.proceed(originalRequest.newBuilder().addHeader("cookie", newCookieHeader).build())
+    }
+
+    fun getNewCookie(url: HttpUrl): Cookie? {
+        val cookies = cookieManager.getCookie(url.toString())
+        val oldCookie = if (cookies != null && cookies.isNotEmpty()) {
+            cookies.split(";").mapNotNull { Cookie.parse(url, it) }
+        } else {
+            emptyList()
+        }
+        val ddg2Cookie = oldCookie.firstOrNull { it.name == "__ddg2_" }
+        if (!ddg2Cookie?.value.isNullOrEmpty()) {
+            return ddg2Cookie
+        }
+        val wellKnown = client.newCall(GET("https://check.ddos-guard.net/check.js"))
+            .execute().body.string()
+            .substringAfter("'", "")
+            .substringBefore("'", "")
+        val checkUrl = "${url.scheme}://${url.host + wellKnown}"
+        return client.newCall(GET(checkUrl)).execute().header("set-cookie")?.let {
+            Cookie.parse(url, it)
+        }
+    }
+
+    companion object {
+        private val ERROR_CODES = listOf(403)
+        private val SERVER_CHECK = listOf("ddos-guard")
+    }
+}

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/DdosGuardInterceptor.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/DdosGuardInterceptor.kt
@@ -34,11 +34,8 @@ class DdosGuardInterceptor(private val client: OkHttpClient) : Interceptor {
         }
 
         val newCookie = getNewCookie(originalRequest.url) ?: return chain.proceed(originalRequest)
-        val newCookieHeader = buildString {
-            (oldCookie + newCookie).forEachIndexed { index, cookie ->
-                if (index > 0) append("; ")
-                append(cookie.name).append('=').append(cookie.value)
-            }
+        val newCookieHeader = (oldCookie + newCookie).joinToString("; ") {
+            "${it.name}=${it.value}"
         }
 
         return chain.proceed(originalRequest.newBuilder().addHeader("cookie", newCookieHeader).build())


### PR DESCRIPTION
No need to open webview to bypass check anymore

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
