### PR TITLE
fix(all/chineseanime): Update baseUrl + add StreamVid extractor

### DIFF
--- a/src/all/chineseanime/build.gradle
+++ b/src/all/chineseanime/build.gradle
@@ -11,5 +11,6 @@ apply from: "$rootDir/common.gradle"
 dependencies {
     implementation(project(":lib:dailymotion-extractor"))
     implementation(project(":lib:streamwish-extractor"))
+    implementation(project(":lib:streamvid-extractor"))
     implementation(project(":lib:playlist-utils"))
 }

--- a/src/all/chineseanime/build.gradle
+++ b/src/all/chineseanime/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ChineseAnime'
     themePkg = 'animestream'
     baseUrl = 'https://www.chineseanime.vip'
-    overrideVersionCode = 5
+    overrideVersionCode = 6
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/chineseanime/build.gradle
+++ b/src/all/chineseanime/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'ChineseAnime'
     extClass = '.ChineseAnime'
     themePkg = 'animestream'
-    baseUrl = 'https://chineseanime.top'
+    baseUrl = 'https://www.chineseanime.vip'
     overrideVersionCode = 5
 }
 

--- a/src/all/chineseanime/src/eu/kanade/tachiyomi/animeextension/all/chineseanime/ChineseAnime.kt
+++ b/src/all/chineseanime/src/eu/kanade/tachiyomi/animeextension/all/chineseanime/ChineseAnime.kt
@@ -11,7 +11,7 @@ import eu.kanade.tachiyomi.multisrc.animestream.AnimeStream
 class ChineseAnime : AnimeStream(
     "all",
     "ChineseAnime",
-    "https://chineseanime.top",
+    "https://www.chineseanime.vip",
 ) {
 
     // =============================== Search ===============================

--- a/src/all/chineseanime/src/eu/kanade/tachiyomi/animeextension/all/chineseanime/ChineseAnime.kt
+++ b/src/all/chineseanime/src/eu/kanade/tachiyomi/animeextension/all/chineseanime/ChineseAnime.kt
@@ -5,6 +5,7 @@ import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.animeextension.all.chineseanime.extractors.VatchusExtractor
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.lib.dailymotionextractor.DailymotionExtractor
+import eu.kanade.tachiyomi.lib.streamvidextractor.StreamVidExtractor
 import eu.kanade.tachiyomi.lib.streamwishextractor.StreamWishExtractor
 import eu.kanade.tachiyomi.multisrc.animestream.AnimeStream
 
@@ -26,14 +27,17 @@ class ChineseAnime : AnimeStream(
     // ============================ Video Links =============================
     private val dailymotionExtractor by lazy { DailymotionExtractor(client, headers) }
     private val streamwishExtractor by lazy { StreamWishExtractor(client, headers) }
+    private val streamvidExtractor by lazy { StreamVidExtractor(client) }
     private val vatchusExtractor by lazy { VatchusExtractor(client, headers) }
 
     override fun getVideoList(url: String, name: String): List<Video> {
         val prefix = "$name - "
+        println("$prefix$url")
         return when {
             url.contains("dailymotion") -> dailymotionExtractor.videosFromUrl(url, prefix)
             url.contains("embedwish") -> streamwishExtractor.videosFromUrl(url, prefix)
             url.contains("vatchus") -> vatchusExtractor.videosFromUrl(url, prefix)
+            url.contains("donghua.xyz/v/") -> streamvidExtractor.videosFromUrl(url, prefix, true)
             else -> emptyList()
         }
     }

--- a/src/all/chineseanime/src/eu/kanade/tachiyomi/animeextension/all/chineseanime/ChineseAnime.kt
+++ b/src/all/chineseanime/src/eu/kanade/tachiyomi/animeextension/all/chineseanime/ChineseAnime.kt
@@ -32,7 +32,6 @@ class ChineseAnime : AnimeStream(
 
     override fun getVideoList(url: String, name: String): List<Video> {
         val prefix = "$name - "
-        println("$prefix$url")
         return when {
             url.contains("dailymotion") -> dailymotionExtractor.videosFromUrl(url, prefix)
             url.contains("embedwish") -> streamwishExtractor.videosFromUrl(url, prefix)


### PR DESCRIPTION
Closes #2977
^ Actually it doesn't, because `playlist-utils` got slightly _trolled_ recently, but everything should work well after _un-trolling_ `playlist-utils` :+1:

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
