### PR TITLE
OppaiStream: Fix url problem with some animes.

### DIFF
--- a/src/en/oppaistream/build.gradle
+++ b/src/en/oppaistream/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Oppai Stream'
     extClass = '.OppaiStream'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = true
 }
 

--- a/src/en/oppaistream/src/eu/kanade/tachiyomi/animeextension/en/oppaistream/OppaiStream.kt
+++ b/src/en/oppaistream/src/eu/kanade/tachiyomi/animeextension/en/oppaistream/OppaiStream.kt
@@ -124,7 +124,11 @@ class OppaiStream : ParsedAnimeHttpSource(), ConfigurableAnimeSource {
     override fun searchAnimeFromElement(element: Element) = SAnime.create().apply {
         thumbnail_url = element.selectFirst("img.cover-img-in")?.attr("abs:src")
         title = element.selectFirst(".title-ep")!!.text().replace(TITLE_CLEANUP_REGEX, "")
-        setUrlWithoutDomain(element.attr("href"))
+        setUrlWithoutDomain(
+            element.attr("href").replace(Regex("(?<=\\?e=)(.*?)(?=&f=)")) {
+                java.net.URLEncoder.encode(it.groupValues[1], "UTF-8")
+            },
+        )
     }
 
     // =========================== Anime Details ============================
@@ -162,7 +166,11 @@ class OppaiStream : ParsedAnimeHttpSource(), ConfigurableAnimeSource {
 
             add(
                 SEpisode.create().apply {
-                    setUrlWithoutDomain(doc.location())
+                    setUrlWithoutDomain(
+                        doc.location().replace(Regex("(?<=\\?e=)(.*?)(?=&f=)")) {
+                            java.net.URLEncoder.encode(it.groupValues[1], "UTF-8")
+                        },
+                    )
                     val num = doc.selectFirst("div.episode-info > h1")!!.text().substringAfter(" Ep ")
                     name = "Episode $num"
                     episode_number = num.toFloatOrNull() ?: 1F
@@ -175,7 +183,11 @@ class OppaiStream : ParsedAnimeHttpSource(), ConfigurableAnimeSource {
     override fun episodeListSelector() = "div.more-same-eps > div > div > a"
 
     override fun episodeFromElement(element: Element) = SEpisode.create().apply {
-        setUrlWithoutDomain(element.attr("href"))
+        setUrlWithoutDomain(
+            element.attr("href").replace(Regex("(?<=\\?e=)(.*?)(?=&f=)")) {
+                java.net.URLEncoder.encode(it.groupValues[1], "UTF-8")
+            },
+        )
         val num = element.selectFirst("font.ep")?.text() ?: "1"
         name = "Episode $num"
         episode_number = num.toFloatOrNull() ?: 1F


### PR DESCRIPTION
- Handled url with special characters.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
