### PR TITLE
Torrentio: Fixed reverse sort order of quality.

### DIFF
--- a/src/all/torrentioanime/build.gradle
+++ b/src/all/torrentioanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Torrentio Anime (Torrent / Debrid)'
     extClass = '.Torrentio'
-    extVersionCode = 5
+    extVersionCode = 6
     containsNsfw = false
 }
 

--- a/src/all/torrentioanime/src/eu/kanade/tachiyomi/animeextension/all/torrentioanime/Torrentio.kt
+++ b/src/all/torrentioanime/src/eu/kanade/tachiyomi/animeextension/all/torrentioanime/Torrentio.kt
@@ -490,11 +490,11 @@ class Torrentio : ConfigurableAnimeSource, AnimeHttpSource() {
 
         return sortedWith(
             compareBy(
-                { !Regex("\\[(.+?) download]").containsMatchIn(it.quality) },
-                { isDub && it.quality.contains("dubbed", true) },
-                { isEfficient && arrayOf("hevc", "265", "av1").any { q -> it.quality.contains(q, true) } },
+                { Regex("\\[(.+?) download]").containsMatchIn(it.quality) },
+                { isDub && !it.quality.contains("dubbed", true) },
+                { isEfficient && !arrayOf("hevc", "265", "av1").any { q -> it.quality.contains(q, true) } },
             ),
-        ).reversed()
+        )
     }
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
