### PR TITLE
fix(pt/animeplayer): Fix popular anime, anime details and episode list pages

### DIFF
--- a/src/pt/animeplayer/build.gradle
+++ b/src/pt/animeplayer/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.AnimePlayer'
     themePkg = 'dooplay'
     baseUrl = 'https://animeplayer.com.br'
-    overrideVersionCode = 2
+    overrideVersionCode = 3
     isNsfw = true
 }
 

--- a/src/pt/animeplayer/src/eu/kanade/tachiyomi/animeextension/pt/animeplayer/AnimePlayer.kt
+++ b/src/pt/animeplayer/src/eu/kanade/tachiyomi/animeextension/pt/animeplayer/AnimePlayer.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.animeextension.pt.animeplayer
 
 import eu.kanade.tachiyomi.animesource.model.SAnime
+import eu.kanade.tachiyomi.animesource.model.SEpisode
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.lib.bloggerextractor.BloggerExtractor
 import eu.kanade.tachiyomi.multisrc.dooplay.DooPlay
@@ -9,6 +10,7 @@ import eu.kanade.tachiyomi.util.asJsoup
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.Response
 import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
 
 class AnimePlayer : DooPlay(
     "pt-BR",
@@ -29,21 +31,60 @@ class AnimePlayer : DooPlay(
     override fun latestUpdatesNextPageSelector() = popularAnimeNextPageSelector()
 
     // =========================== Anime Details ============================
-    override fun animeDetailsParse(document: Document): SAnime {
+    override fun animeDetailsParse(document: Document) = SAnime.create().apply {
         val doc = getRealAnimeDoc(document)
         val content = doc.selectFirst("div#contenedor > div.data")!!
-        return SAnime.create().apply {
-            doc.selectFirst("div.sheader div.poster > img")!!.let {
-                thumbnail_url = it.getImageUrl()
-                title = it.attr("alt").ifEmpty {
-                    content.selectFirst("div.data > h1")!!.text()
-                }
+        doc.selectFirst("div.sheader div.poster > img")!!.let {
+            thumbnail_url = it.getImageUrl()
+            title = it.attr("alt").ifEmpty {
+                content.selectFirst("div.data > h1")!!.text()
             }
-
-            genre = content.select("div.sgeneros > a")
-                .eachText()
-                .joinToString()
         }
+
+        genre = content.select("div.sgeneros > a")
+            .eachText()
+            .joinToString()
+    }
+
+    // ============================== Episodes ==============================
+    override fun episodeListParse(response: Response): List<SEpisode> {
+        val doc = getRealAnimeDoc(response.asJsoup())
+        val seasonList = doc.select(seasonListSelector)
+        return if (seasonList.size < 1) {
+            SEpisode.create().apply {
+                setUrlWithoutDomain(doc.location())
+                episode_number = 1F
+                name = episodeMovieText
+            }.let(::listOf)
+        } else {
+            seasonList.flatMap(::getSeasonEpisodes)
+        }
+    }
+
+    override fun getSeasonEpisodes(season: Element): List<SEpisode> {
+        val seasonName = season.selectFirst("span.title")!!.text()
+        return season.select(episodeListSelector()).mapNotNull { element ->
+            try {
+                episodeFromElement(element, seasonName)
+            } catch (e: Throwable) {
+                e.printStackTrace()
+                null
+            }
+        }
+    }
+
+    override fun episodeFromElement(element: Element): SEpisode = throw UnsupportedOperationException()
+
+    override fun episodeFromElement(element: Element, seasonName: String) = SEpisode.create().apply {
+        val epNum = element.selectFirst("div.episodiotitle p")!!.text()
+            .trim()
+            .let(episodeNumberRegex::find)
+            ?.groupValues
+            ?.last() ?: "0"
+        val href = element.selectFirst("a[href]")!!
+        episode_number = epNum.toFloatOrNull() ?: 0F
+        name = "$seasonName x Episódio $epNum"
+        setUrlWithoutDomain(href.absUrl("href"))
     }
 
     // ============================ Video Links =============================

--- a/src/pt/animeplayer/src/eu/kanade/tachiyomi/animeextension/pt/animeplayer/AnimePlayer.kt
+++ b/src/pt/animeplayer/src/eu/kanade/tachiyomi/animeextension/pt/animeplayer/AnimePlayer.kt
@@ -65,4 +65,7 @@ class AnimePlayer : DooPlay(
 
     // ============================== Filters ===============================
     override fun genresListSelector() = "ul.genres a"
+
+    // ============================= Utilities ==============================
+    override val animeMenuSelector = "div.pag_episodes div.item a[href] i.icon-bars"
 }

--- a/src/pt/animeplayer/src/eu/kanade/tachiyomi/animeextension/pt/animeplayer/AnimePlayer.kt
+++ b/src/pt/animeplayer/src/eu/kanade/tachiyomi/animeextension/pt/animeplayer/AnimePlayer.kt
@@ -15,14 +15,16 @@ class AnimePlayer : DooPlay(
 ) {
 
     // ============================== Popular ===============================
-    override fun popularAnimeSelector() = "div#featured-titles article div.poster"
+    override fun popularAnimeSelector() = "div#archive-content article div.poster"
 
     override fun popularAnimeRequest(page: Int) = GET("$baseUrl/animes/")
+
+    override fun popularAnimeNextPageSelector() = "a > i#nextpagination"
 
     // =============================== Latest ===============================
     override val latestUpdatesPath = "episodios"
 
-    override fun latestUpdatesNextPageSelector() = "a > i#nextpagination"
+    override fun latestUpdatesNextPageSelector() = popularAnimeNextPageSelector()
 
     // ============================ Video Links =============================
     override val prefQualityValues = arrayOf("360p", "720p")


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
