### PR TITLE
fix(all/sudatchi): replaced api calls with NEXT json

### DIFF
--- a/src/all/sudatchi/build.gradle
+++ b/src/all/sudatchi/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Sudatchi'
     extClass = '.Sudatchi'
-    extVersionCode = 2
+    extVersionCode = 3
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/sudatchi/build.gradle
+++ b/src/all/sudatchi/build.gradle
@@ -2,6 +2,7 @@ ext {
     extName = 'Sudatchi'
     extClass = '.Sudatchi'
     extVersionCode = 3
+    isNsfw = true
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/sudatchi/src/eu/kanade/tachiyomi/animeextension/all/sudatchi/dto/SudatchiDto.kt
+++ b/src/all/sudatchi/src/eu/kanade/tachiyomi/animeextension/all/sudatchi/dto/SudatchiDto.kt
@@ -35,35 +35,32 @@ data class AnimeDto(
 )
 
 @Serializable
-data class HomePagePropsPagePropsDto(
+data class HomePageDto(
     @SerialName("AnimeSpotlight")
     val animeSpotlight: List<AnimeDto>,
 )
 
 @Serializable
-data class HomePagePropsDto(
-    val pageProps: HomePagePropsPagePropsDto,
-)
-
-@Serializable
-data class HomePageDto(
-    val props: HomePagePropsDto,
-)
-
-@Serializable
-data class AnimePagePropsPagePropsDto(
+data class AnimePageDto(
     val animeData: AnimeDto,
 )
 
 @Serializable
-data class AnimePagePropsDto(
-    val pageProps: AnimePagePropsPagePropsDto,
+data class EpisodeDataDto(
+    val episode: EpisodeDto,
+    val subtitlesJson: String,
 )
 
 @Serializable
-data class AnimePageDto(
-    val props: AnimePagePropsDto,
+data class EpisodePageDto(
+    val episodeData: EpisodeDataDto,
 )
+
+@Serializable
+data class PagePropsDto<T>(val pageProps: T)
+
+@Serializable
+data class PropsDto<T>(val props: PagePropsDto<T>)
 
 @Serializable
 data class DirectoryDto(
@@ -83,27 +80,6 @@ data class SubtitleDto(
     val url: String,
     @SerialName("SubtitlesName")
     val subtitlesName: SubtitleLangDto,
-)
-
-@Serializable
-data class EpisodeDataDto(
-    val episode: EpisodeDto,
-    val subtitlesJson: String,
-)
-
-@Serializable
-data class EpisodePagePropsPagePropsDto(
-    val episodeData: EpisodeDataDto,
-)
-
-@Serializable
-data class EpisodePagePropsDto(
-    val pageProps: EpisodePagePropsPagePropsDto,
-)
-
-@Serializable
-data class EpisodePageDto(
-    val props: EpisodePagePropsDto,
 )
 
 @Serializable

--- a/src/all/sudatchi/src/eu/kanade/tachiyomi/animeextension/all/sudatchi/dto/SudatchiDto.kt
+++ b/src/all/sudatchi/src/eu/kanade/tachiyomi/animeextension/all/sudatchi/dto/SudatchiDto.kt
@@ -4,16 +4,23 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class Genre(val name: String)
+data class GenreDto(val name: String)
 
 @Serializable
-data class AnimeGenreRelation(
+data class AnimeGenreRelationDto(
     @SerialName("Genre")
-    val genre: Genre,
+    val genre: GenreDto,
 )
 
 @Serializable
-data class ShortAnimeDto(
+data class EpisodeDto(
+    val title: String,
+    val id: Int,
+    val number: Int,
+)
+
+@Serializable
+data class AnimeDto(
     val titleRomanji: String?,
     val titleEnglish: String?,
     val titleJapanese: String?,
@@ -22,44 +29,47 @@ data class ShortAnimeDto(
     val statusId: Int,
     val imgUrl: String,
     @SerialName("AnimeGenres")
-    val animeGenres: List<AnimeGenreRelation>?,
+    val animeGenres: List<AnimeGenreRelationDto>?,
+    @SerialName("Episodes")
+    val episodes: List<EpisodeDto> = emptyList(),
 )
 
 @Serializable
-data class HomePagePropsPageProps(
+data class HomePagePropsPagePropsDto(
     @SerialName("AnimeSpotlight")
-    val animeSpotlight: List<ShortAnimeDto>,
+    val animeSpotlight: List<AnimeDto>,
 )
 
 @Serializable
-data class HomePageProps(
-    val pageProps: HomePagePropsPageProps,
+data class HomePagePropsDto(
+    val pageProps: HomePagePropsPagePropsDto,
 )
 
 @Serializable
 data class HomePageDto(
-    val props: HomePageProps,
+    val props: HomePagePropsDto,
+)
+
+@Serializable
+data class AnimePagePropsPagePropsDto(
+    val animeData: AnimeDto,
+)
+
+@Serializable
+data class AnimePagePropsDto(
+    val pageProps: AnimePagePropsPagePropsDto,
+)
+
+@Serializable
+data class AnimePageDto(
+    val props: AnimePagePropsDto,
 )
 
 @Serializable
 data class DirectoryDto(
-    val animes: List<ShortAnimeDto>,
+    val animes: List<AnimeDto>,
     val page: Int,
     val pages: Int,
-)
-
-@Serializable
-data class Episode(
-    val title: String,
-    val id: Int,
-    val number: Int,
-)
-
-@Serializable
-data class LongAnimeDto(
-    val slug: String,
-    @SerialName("Episodes")
-    val episodes: List<Episode>,
 )
 
 @Serializable
@@ -77,23 +87,23 @@ data class SubtitleDto(
 
 @Serializable
 data class EpisodeDataDto(
-    val episode: Episode,
+    val episode: EpisodeDto,
     val subtitlesJson: String,
 )
 
 @Serializable
-data class PagePropsDto(
+data class EpisodePagePropsPagePropsDto(
     val episodeData: EpisodeDataDto,
 )
 
 @Serializable
-data class DataWatchDto(
-    val pageProps: PagePropsDto,
+data class EpisodePagePropsDto(
+    val pageProps: EpisodePagePropsPagePropsDto,
 )
 
 @Serializable
-data class WatchDto(
-    val props: DataWatchDto,
+data class EpisodePageDto(
+    val props: EpisodePagePropsDto,
 )
 
 @Serializable

--- a/src/all/sudatchi/src/eu/kanade/tachiyomi/animeextension/all/sudatchi/dto/SudatchiDto.kt
+++ b/src/all/sudatchi/src/eu/kanade/tachiyomi/animeextension/all/sudatchi/dto/SudatchiDto.kt
@@ -26,9 +26,19 @@ data class ShortAnimeDto(
 )
 
 @Serializable
-data class HomeListDto(
+data class HomePagePropsPageProps(
     @SerialName("AnimeSpotlight")
     val animeSpotlight: List<ShortAnimeDto>,
+)
+
+@Serializable
+data class HomePageProps(
+    val pageProps: HomePagePropsPageProps,
+)
+
+@Serializable
+data class HomePageDto(
+    val props: HomePageProps,
 )
 
 @Serializable


### PR DESCRIPTION
Closes #3299 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have tested the modifications by compiling and running the extension through Android Studio
