### PR TITLE
preference(jellyfin): Add option to hide extension affixes

### DIFF
--- a/src/all/jellyfin/build.gradle
+++ b/src/all/jellyfin/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Jellyfin'
     extClass = '.JellyfinFactory'
-    extVersionCode = 15
+    extVersionCode = 16
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/jellyfin/src/eu/kanade/tachiyomi/animeextension/all/jellyfin/JellyfinDto.kt
+++ b/src/all/jellyfin/src/eu/kanade/tachiyomi/animeextension/all/jellyfin/JellyfinDto.kt
@@ -137,15 +137,20 @@ data class ItemDto(
         epDetails: Set<String>,
         epType: EpisodeType,
         prefix: String,
+        removeAffixes: Boolean,
     ): SEpisode = SEpisode.create().apply {
         when (epType) {
             EpisodeType.MOVIE -> {
                 episode_number = 1F
-                name = "${prefix}Movie"
+                name = if (removeAffixes && prefix.isNotBlank()) prefix else "${prefix}Movie"
             }
             EpisodeType.EPISODE -> {
-                episode_number = indexNumber?.toFloat() ?: 1F
-                name = "${prefix}Ep. $indexNumber - ${this@ItemDto.name}"
+                name = if (indexNumber == null) {
+                    "${prefix}${this@ItemDto.name}"
+                } else {
+                    episode_number = indexNumber.toFloat()
+                    "${prefix}Ep. $indexNumber - ${this@ItemDto.name}"
+                }
             }
         }
 

--- a/src/all/jellyfin/src/eu/kanade/tachiyomi/animeextension/all/jellyfin/JellyfinDto.kt
+++ b/src/all/jellyfin/src/eu/kanade/tachiyomi/animeextension/all/jellyfin/JellyfinDto.kt
@@ -145,11 +145,13 @@ data class ItemDto(
                 name = if (removeAffixes && prefix.isNotBlank()) prefix else "${prefix}Movie"
             }
             EpisodeType.EPISODE -> {
-                name = if (indexNumber == null) {
+                name = if (indexNumber == null || removeAffixes) {
                     "${prefix}${this@ItemDto.name}"
                 } else {
-                    episode_number = indexNumber.toFloat()
                     "${prefix}Ep. $indexNumber - ${this@ItemDto.name}"
+                }
+                indexNumber?.let {
+                    episode_number = it.toFloat()
                 }
             }
         }


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
